### PR TITLE
Allow to configure pg server version

### DIFF
--- a/conn.go
+++ b/conn.go
@@ -49,6 +49,7 @@ const (
 	ParamApplicationName      ParameterStatus = "application_name"
 	ParamDatabase             ParameterStatus = "database"
 	ParamUsername             ParameterStatus = "user"
+	ParamServerVersion        ParameterStatus = "server_version"
 )
 
 // setClientParameters constructs a new context containing the given parameters.

--- a/handshake.go
+++ b/handshake.go
@@ -103,7 +103,9 @@ func (srv *Server) writeParameters(ctx context.Context, writer *buffer.Writer, p
 
 	params[ParamServerEncoding] = "UTF8"
 	params[ParamClientEncoding] = "UTF8"
-	params[ParamServerVersion] = "13.0"
+	if srv.Version != "" {
+		params[ParamServerVersion] = srv.Version
+	}
 	params[ParamIsSuperuser] = buffer.EncodeBoolean(IsSuperUser(ctx))
 	params[ParamSessionAuthorization] = AuthenticatedUsername(ctx)
 

--- a/handshake.go
+++ b/handshake.go
@@ -103,6 +103,7 @@ func (srv *Server) writeParameters(ctx context.Context, writer *buffer.Writer, p
 
 	params[ParamServerEncoding] = "UTF8"
 	params[ParamClientEncoding] = "UTF8"
+	params[ParamServerVersion] = "13.0"
 	params[ParamIsSuperuser] = buffer.EncodeBoolean(IsSuperUser(ctx))
 	params[ParamSessionAuthorization] = AuthenticatedUsername(ctx)
 

--- a/options.go
+++ b/options.go
@@ -79,3 +79,11 @@ func Logger(logger *zap.Logger) OptionFn {
 		srv.logger = logger
 	}
 }
+
+// Version sets the PostgreSQL version for the server which is send back to the
+// front-end (client) once a handshake has been established.
+func Version(version string) OptionFn {
+	return func(srv *Server) {
+		srv.Version = version
+	}
+}

--- a/wire.go
+++ b/wire.go
@@ -52,6 +52,7 @@ type Server struct {
 	SimpleQuery     SimpleQueryFn
 	CloseConn       CloseFn
 	TerminateConn   CloseFn
+	Version         string
 	closer          chan struct{}
 }
 


### PR DESCRIPTION
I see that there is a function `GlobalParameters` to override all the options. But I think a separate function would be easier to use.