### PR TITLE
Extended queries support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 bin/
+.vscode/

--- a/cache.go
+++ b/cache.go
@@ -1,0 +1,41 @@
+package wire
+
+import (
+	"context"
+	"sync"
+)
+
+type DefaultStatementCache struct {
+	statements map[string]PreparedStatementFn
+	mu         sync.RWMutex
+}
+
+// Set attempts to bind the given statement to the given name. Any
+// previously defined statement is overridden.
+func (cache *DefaultStatementCache) Set(ctx context.Context, name string, fn PreparedStatementFn) error {
+	cache.mu.Lock()
+	defer cache.mu.Unlock()
+
+	if cache.statements == nil {
+		cache.statements = map[string]PreparedStatementFn{}
+	}
+
+	cache.statements[name] = fn
+	return nil
+}
+
+// Get attempts to get the prepared statement for the given name. An error
+// is returned when no statement has been found.
+func (cache *DefaultStatementCache) Get(ctx context.Context, name string) (PreparedStatementFn, error) {
+	cache.mu.RLock()
+	defer cache.mu.RUnlock()
+
+	if cache.statements == nil {
+		return nil, nil
+	}
+
+	return cache.statements[name], nil
+}
+
+type DefaultPortalCache struct {
+}

--- a/command.go
+++ b/command.go
@@ -22,9 +22,12 @@ func NewErrUnimplementedMessageType(t types.ClientMessage) error {
 	return psqlerr.WithSeverity(psqlerr.WithCode(err, codes.ConnectionDoesNotExist), psqlerr.LevelFatal)
 }
 
-type SimpleQueryFn func(ctx context.Context, query string, writer DataWriter) error
-
-type CloseFn func(ctx context.Context) error
+// NewErrUnkownStatement is returned whenever no executable has been found for
+// the given name.
+func NewErrUnkownStatement(name string) error {
+	err := fmt.Errorf("unknown executeable: %s", name)
+	return psqlerr.WithSeverity(psqlerr.WithCode(err, codes.InvalidPreparedStatementDefinition), psqlerr.LevelFatal)
+}
 
 // consumeCommands consumes incoming commands send over the Postgres wire connection.
 // Commands consumed from the connection are returned through a go channel.
@@ -97,6 +100,7 @@ func (srv *Server) handleMessageSizeExceeded(reader *buffer.Reader, writer *buff
 // handleCommand handles the given client message. A client message includes a
 // message type and reader buffer containing the actual message. The type
 // indecates a action executed by the client.
+// https://www.postgresql.org/docs/14/protocol-message-formats.html
 func (srv *Server) handleCommand(ctx context.Context, conn net.Conn, t types.ClientMessage, reader *buffer.Reader, writer *buffer.Writer) (err error) {
 	ctx, cancel := context.WithCancel(ctx)
 	defer cancel()
@@ -104,13 +108,35 @@ func (srv *Server) handleCommand(ctx context.Context, conn net.Conn, t types.Cli
 	switch t {
 	case types.ClientSync:
 		// TODO(Jeroen): client sync received
+		fmt.Println("Sync!")
 	case types.ClientSimpleQuery:
 		return srv.handleSimpleQuery(ctx, reader, writer)
 	case types.ClientExecute:
+		return srv.handleExecute(ctx, reader, writer)
 	case types.ClientParse:
+		return srv.handleParse(ctx, reader, writer)
 	case types.ClientDescribe:
+		fmt.Println("Describe Message:")
+		fmt.Println(reader.GetBytes(1)) // 'S' to describe a prepared statement; or 'P' to describe a portal.
+		fmt.Println(reader.GetString()) // The name of the prepared statement or portal to describe (an empty string selects the unnamed prepared statement or portal).
 	case types.ClientBind:
+		fmt.Println("Bind Message Type:")
+		fmt.Println(reader.GetString()) // name bind
+		fmt.Println(reader.GetString()) // name statement
+		fmt.Println(reader.GetUint16()) // number of parameters
+		fmt.Println(reader.GetUint16()) // parameter format code
+		fmt.Println(reader.GetUint16()) // number of parameters that will follow
+
+		fmt.Println(reader.GetUint32()) // length of the value
+		fmt.Println(reader.GetBytes(0)) // value in bytes (based on length)
+		fmt.Println(reader.GetUint16()) // The number of result-column format codes that follow
+		fmt.Println(reader.GetUint16()) // The result-column format codes
+
+		writer.Start(types.ServerBindComplete)
+		writer.End() //nolint:errcheck
 	case types.ClientFlush:
+		// TODO(Jeroen): flush received
+		fmt.Println("Flush!")
 	case types.ClientCopyData, types.ClientCopyDone, types.ClientCopyFail:
 		// We're supposed to ignore these messages, per the protocol spec. This
 		// state will happen when an error occurs on the server-side during a copy
@@ -140,7 +166,7 @@ func (srv *Server) handleCommand(ctx context.Context, conn net.Conn, t types.Cli
 }
 
 func (srv *Server) handleSimpleQuery(ctx context.Context, reader *buffer.Reader, writer *buffer.Writer) error {
-	if srv.SimpleQuery == nil {
+	if srv.Parse == nil {
 		return ErrorCode(writer, NewErrUnimplementedMessageType(types.ClientSimpleQuery))
 	}
 
@@ -151,11 +177,100 @@ func (srv *Server) handleSimpleQuery(ctx context.Context, reader *buffer.Reader,
 
 	srv.logger.Debug("incoming query", zap.String("query", query))
 
-	err = srv.SimpleQuery(ctx, query, &dataWriter{
+	statement, err := srv.Parse(ctx, query)
+	if err != nil {
+		return err
+	}
+
+	if err != nil {
+		return ErrorCode(writer, err)
+	}
+
+	err = statement(ctx, &dataWriter{
 		ctx:    ctx,
 		client: writer,
 	})
 
+	if err != nil {
+		return ErrorCode(writer, err)
+	}
+
+	return nil
+}
+
+func (srv *Server) handleParse(ctx context.Context, reader *buffer.Reader, writer *buffer.Writer) error {
+	if srv.Parse == nil || srv.Statements == nil {
+		return ErrorCode(writer, NewErrUnimplementedMessageType(types.ClientParse))
+	}
+
+	name, err := reader.GetString()
+	if err != nil {
+		return err
+	}
+
+	query, err := reader.GetString()
+	if err != nil {
+		return err
+	}
+
+	// TODO(Jeroen): reader.GetUint16()
+	// The number of parameter data types specified (can be zero). Note that
+	// this is not an indication of the number of parameters that might appear
+	// in the query string, only the number that the frontend wants to
+	// prespecify types for.
+
+	// TODO(Jeroen): reader.GetUint32()
+	// Specifies the object ID of the parameter data type. Placing a zero here
+	// is equivalent to leaving the type unspecified.
+
+	srv.logger.Debug("incoming query", zap.String("query", query), zap.String("name", name))
+
+	statement, err := srv.Parse(ctx, query)
+	if err != nil {
+		return ErrorCode(writer, err)
+	}
+
+	err = srv.Statements.Set(ctx, name, statement)
+	if err != nil {
+		return ErrorCode(writer, err)
+	}
+
+	writer.Start(types.ServerParseComplete)
+	writer.End() //nolint:errcheck
+
+	return nil
+}
+
+func (srv *Server) handleExecute(ctx context.Context, reader *buffer.Reader, writer *buffer.Writer) error {
+	if srv.Statements == nil {
+		return ErrorCode(writer, NewErrUnimplementedMessageType(types.ClientExecute))
+	}
+
+	name, err := reader.GetString()
+	if err != nil {
+		return err
+	}
+
+	fmt.Println("execute name", name)
+
+	// TODO(Jeroen): reader.GetUint32()
+	// Maximum number of rows to return, if portal
+	// contains a query that returns rows (ignored otherwise). Zero denotes “no
+	// limit”.
+
+	statement, err := srv.Statements.Get(ctx, name)
+	if err != nil {
+		return ErrorCode(writer, err)
+	}
+
+	if statement == nil {
+		return ErrorCode(writer, NewErrUnkownStatement(name))
+	}
+
+	err = statement(ctx, &dataWriter{
+		ctx:    ctx,
+		client: writer,
+	})
 	if err != nil {
 		return ErrorCode(writer, err)
 	}

--- a/command.go
+++ b/command.go
@@ -108,7 +108,6 @@ func (srv *Server) handleCommand(ctx context.Context, conn net.Conn, t types.Cli
 	switch t {
 	case types.ClientSync:
 		// TODO(Jeroen): client sync received
-		fmt.Println("Sync!")
 	case types.ClientSimpleQuery:
 		return srv.handleSimpleQuery(ctx, reader, writer)
 	case types.ClientExecute:
@@ -120,20 +119,7 @@ func (srv *Server) handleCommand(ctx context.Context, conn net.Conn, t types.Cli
 		fmt.Println(reader.GetBytes(1)) // 'S' to describe a prepared statement; or 'P' to describe a portal.
 		fmt.Println(reader.GetString()) // The name of the prepared statement or portal to describe (an empty string selects the unnamed prepared statement or portal).
 	case types.ClientBind:
-		fmt.Println("Bind Message Type:")
-		fmt.Println(reader.GetString()) // name bind
-		fmt.Println(reader.GetString()) // name statement
-		fmt.Println(reader.GetUint16()) // number of parameters
-		fmt.Println(reader.GetUint16()) // parameter format code
-		fmt.Println(reader.GetUint16()) // number of parameters that will follow
-
-		fmt.Println(reader.GetUint32()) // length of the value
-		fmt.Println(reader.GetBytes(0)) // value in bytes (based on length)
-		fmt.Println(reader.GetUint16()) // The number of result-column format codes that follow
-		fmt.Println(reader.GetUint16()) // The result-column format codes
-
-		writer.Start(types.ServerBindComplete)
-		writer.End() //nolint:errcheck
+		return srv.handleBind(ctx, reader, writer)
 	case types.ClientFlush:
 		// TODO(Jeroen): flush received
 		fmt.Println("Flush!")
@@ -186,11 +172,7 @@ func (srv *Server) handleSimpleQuery(ctx context.Context, reader *buffer.Reader,
 		return ErrorCode(writer, err)
 	}
 
-	err = statement(ctx, &dataWriter{
-		ctx:    ctx,
-		client: writer,
-	})
-
+	err = statement(ctx, NewDataWriter(ctx, writer))
 	if err != nil {
 		return ErrorCode(writer, err)
 	}
@@ -241,6 +223,59 @@ func (srv *Server) handleParse(ctx context.Context, reader *buffer.Reader, write
 	return nil
 }
 
+func (srv *Server) handleBind(ctx context.Context, reader *buffer.Reader, writer *buffer.Writer) error {
+	name, err := reader.GetString()
+	if err != nil {
+		return err
+	}
+
+	statement, err := reader.GetString()
+	if err != nil {
+		return err
+	}
+
+	_, err = srv.readParameters(ctx, reader)
+	if err != nil {
+		return err
+	}
+
+	fn, err := srv.Statements.Get(ctx, statement)
+	if err != nil {
+		return err
+	}
+
+	err = srv.Portals.Bind(ctx, name, fn)
+	if err != nil {
+		return err
+	}
+
+	writer.Start(types.ServerBindComplete)
+	return writer.End()
+}
+
+func (srv *Server) readParameters(ctx context.Context, reader *buffer.Reader) ([]interface{}, error) {
+	length, err := reader.GetUint16()
+	if err != nil {
+		return nil, err
+	}
+
+	srv.logger.Debug("reading parameters", zap.Uint16("length", length))
+	if length == 0 {
+		return nil, nil
+	}
+
+	for i := uint16(0); i < length; i++ {
+		fmt.Println(reader.GetUint16()) // parameter format code
+		fmt.Println(reader.GetUint16()) // number of parameters that will follow
+		fmt.Println(reader.GetUint32()) // length of the value
+		fmt.Println(reader.GetBytes(0)) // value in bytes (based on length)
+		fmt.Println(reader.GetUint16()) // The number of result-column format codes that follow
+		fmt.Println(reader.GetUint16()) // The result-column format codes
+	}
+
+	return nil, nil
+}
+
 func (srv *Server) handleExecute(ctx context.Context, reader *buffer.Reader, writer *buffer.Writer) error {
 	if srv.Statements == nil {
 		return ErrorCode(writer, NewErrUnimplementedMessageType(types.ClientExecute))
@@ -251,31 +286,13 @@ func (srv *Server) handleExecute(ctx context.Context, reader *buffer.Reader, wri
 		return err
 	}
 
-	fmt.Println("execute name", name)
-
 	// TODO(Jeroen): reader.GetUint32()
 	// Maximum number of rows to return, if portal
 	// contains a query that returns rows (ignored otherwise). Zero denotes “no
 	// limit”.
 
-	statement, err := srv.Statements.Get(ctx, name)
-	if err != nil {
-		return ErrorCode(writer, err)
-	}
-
-	if statement == nil {
-		return ErrorCode(writer, NewErrUnkownStatement(name))
-	}
-
-	err = statement(ctx, &dataWriter{
-		ctx:    ctx,
-		client: writer,
-	})
-	if err != nil {
-		return ErrorCode(writer, err)
-	}
-
-	return nil
+	srv.logger.Debug("executing", zap.String("name", name))
+	return srv.Portals.Execute(ctx, name, NewDataWriter(ctx, writer))
 }
 
 func (srv *Server) handleConnClose(ctx context.Context) error {

--- a/handshake.go
+++ b/handshake.go
@@ -62,7 +62,7 @@ func readyForQuery(writer *buffer.Writer, status types.ServerStatus) error {
 // readParameters reads the key/value connection parameters send by the client and
 // The read parameters will be set inside the given context. A new context containing
 // the consumed parameters will be returned.
-func (srv *Server) readParameters(ctx context.Context, reader *buffer.Reader) (_ context.Context, err error) {
+func (srv *Server) readClientParameters(ctx context.Context, reader *buffer.Reader) (_ context.Context, err error) {
 	meta := make(Parameters)
 
 	srv.logger.Debug("reading client parameters")

--- a/options.go
+++ b/options.go
@@ -1,11 +1,43 @@
 package wire
 
 import (
+	"context"
 	"crypto/tls"
 	"crypto/x509"
 
 	"go.uber.org/zap"
 )
+
+type SimpleQueryFn func(ctx context.Context, query string, writer DataWriter) error
+
+// ParseFn parses the given query and returns a prepared statement which could
+// be used to execute at a later point in time.
+type ParseFn func(ctx context.Context, query string) (PreparedStatementFn, error)
+
+// PreparedStatementFn represents a query of which a statement has been
+// prepared. The statement could be executed at any point in time with the given
+// arguments and data writer.
+type PreparedStatementFn func(ctx context.Context, writer DataWriter) error
+
+// StatementCache represents a cache which could be used to store and retrieve
+// prepared statements bound to a name.
+type StatementCache interface {
+	// Set attempts to bind the given statement to the given name. Any
+	// previously defined statement is overridden.
+	Set(ctx context.Context, name string, fn PreparedStatementFn) error
+	// Get attempts to get the prepared statement for the given name. An error
+	// is returned when no statement has been found.
+	Get(ctx context.Context, name string) (PreparedStatementFn, error)
+}
+
+
+type PortalCache interface {
+	Set(ctx context.Context) error
+	Remove(ctx context.Context)
+	Get(ctx context.Context) error
+}
+
+type CloseFn func(ctx context.Context) error
 
 // OptionFn options pattern used to define and set options for the given
 // PostgreSQL server.
@@ -14,7 +46,32 @@ type OptionFn func(*Server)
 // SimpleQuery sets the simple query handle inside the given server instance.
 func SimpleQuery(fn SimpleQueryFn) OptionFn {
 	return func(srv *Server) {
-		srv.SimpleQuery = fn
+		if srv.Parse != nil {
+			return
+		}
+
+		srv.Parse = func(ctx context.Context, query string) (PreparedStatementFn, error) {
+			statement := func(ctx context.Context, writer DataWriter) error {
+				return fn(ctx, query, writer)
+			}
+
+			return statement, nil
+		}
+	}
+}
+
+// Parse sets the given parse function used to parse queries into prepared statements.
+func Parse(fn ParseFn) OptionFn {
+	return func(srv *Server) {
+		srv.Parse = fn
+	}
+}
+
+// Cache sets the statement cache used to cache statements for later use. By
+// default is the DefaultStatementCache used to cache prepared statements.
+func Cache(fn StatementCache) OptionFn {
+	return func(srv *Server) {
+		srv.Statements = fn
 	}
 }
 

--- a/options.go
+++ b/options.go
@@ -30,11 +30,11 @@ type StatementCache interface {
 	Get(ctx context.Context, name string) (PreparedStatementFn, error)
 }
 
-
+// PortalCache represents a cache which could be used to bind and execute
+// prepared statements with parameters.
 type PortalCache interface {
-	Set(ctx context.Context) error
-	Remove(ctx context.Context)
-	Get(ctx context.Context) error
+	Bind(ctx context.Context, name string, statement PreparedStatementFn) error
+	Execute(ctx context.Context, name string, writer DataWriter) error
 }
 
 type CloseFn func(ctx context.Context) error
@@ -67,11 +67,19 @@ func Parse(fn ParseFn) OptionFn {
 	}
 }
 
-// Cache sets the statement cache used to cache statements for later use. By
+// Statements sets the statement cache used to cache statements for later use. By
 // default is the DefaultStatementCache used to cache prepared statements.
-func Cache(fn StatementCache) OptionFn {
+func Statements(cache StatementCache) OptionFn {
 	return func(srv *Server) {
-		srv.Statements = fn
+		srv.Statements = cache
+	}
+}
+
+// Portals sets the portals cache used to cache statements for later use. By
+// default is the DefaultPortalCache used to evaluate portals.
+func Portals(cache PortalCache) OptionFn {
+	return func(srv *Server) {
+		srv.Portals = cache
 	}
 }
 

--- a/wire.go
+++ b/wire.go
@@ -31,6 +31,7 @@ func NewServer(options ...OptionFn) (*Server, error) {
 		logger:     zap.NewNop(),
 		closer:     make(chan struct{}),
 		Statements: &DefaultStatementCache{},
+		Portals:    &DefaultPortalCache{},
 	}
 
 	for _, option := range options {
@@ -128,7 +129,7 @@ func (srv *Server) serve(ctx context.Context, conn net.Conn) error {
 	srv.logger.Debug("handshake successfull, validating authentication")
 
 	writer := buffer.NewWriter(conn)
-	ctx, err = srv.readParameters(ctx, reader)
+	ctx, err = srv.readClientParameters(ctx, reader)
 	if err != nil {
 		return err
 	}

--- a/wire.go
+++ b/wire.go
@@ -28,8 +28,9 @@ func ListenAndServe(address string, handler SimpleQueryFn) error {
 // NewServer constructs a new Postgres server using the given address and server options.
 func NewServer(options ...OptionFn) (*Server, error) {
 	srv := &Server{
-		logger: zap.NewNop(),
-		closer: make(chan struct{}),
+		logger:     zap.NewNop(),
+		closer:     make(chan struct{}),
+		Statements: &DefaultStatementCache{},
 	}
 
 	for _, option := range options {
@@ -49,7 +50,9 @@ type Server struct {
 	Certificates    []tls.Certificate
 	ClientCAs       *x509.CertPool
 	ClientAuth      tls.ClientAuthType
-	SimpleQuery     SimpleQueryFn
+	Parse           ParseFn
+	Statements      StatementCache
+	Portals         PortalCache
 	CloseConn       CloseFn
 	TerminateConn   CloseFn
 	closer          chan struct{}

--- a/wire_test.go
+++ b/wire_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/jeroenrinzema/psql-wire/internal/mock"
 	_ "github.com/lib/pq"
 	"github.com/lib/pq/oid"
+	"go.uber.org/zap"
 )
 
 // TListenAndServe will open a new TCP listener on a unallocated port inside
@@ -134,7 +135,8 @@ func TestServerWritingResult(t *testing.T) {
 		return writer.Complete("OK")
 	}
 
-	server, err := NewServer(SimpleQuery(handler))
+	d, _ := zap.NewDevelopment()
+	server, err := NewServer(SimpleQuery(handler), Logger(d))
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -171,38 +173,38 @@ func TestServerWritingResult(t *testing.T) {
 		}
 	})
 
-	// NOTE(Jeroen): the jackc/pgx test has been disabled due to a lock of
+	// NOTE(Jeroen): the jackc/pgx test has been disabled due to a lack of
 	// support for parse, describe, and execute messages. This test could be
 	// enabled again once these message types are supported.
-	// t.Run("jackc/pgx", func(t *testing.T) {
-	// 	ctx := context.Background()
-	// 	connstr := fmt.Sprintf("postgres://%s:%d", address.IP, address.Port)
-	// 	conn, err := pgx.Connect(ctx, connstr)
-	// 	if err != nil {
-	// 		t.Fatal(err)
-	// 	}
+	t.Run("jackc/pgx", func(t *testing.T) {
+		ctx := context.Background()
+		connstr := fmt.Sprintf("postgres://%s:%d", address.IP, address.Port)
+		conn, err := pgx.Connect(ctx, connstr)
+		if err != nil {
+			t.Fatal(err)
+		}
 
-	// 	rows, err := conn.Query(ctx, "SELECT *;")
-	// 	if err != nil {
-	// 		t.Fatal(err)
-	// 	}
+		rows, err := conn.Query(ctx, "SELECT *;")
+		if err != nil {
+			t.Fatal(err)
+		}
 
-	// 	for rows.Next() {
-	// 		var name string
-	// 		var member bool
-	// 		var age int
+		for rows.Next() {
+			var name string
+			var member bool
+			var age int
 
-	// 		err := rows.Scan(&name, &member, &age)
-	// 		if err != nil {
-	// 			t.Fatal(err)
-	// 		}
+			err := rows.Scan(&name, &member, &age)
+			if err != nil {
+				t.Fatal(err)
+			}
 
-	// 		t.Logf("scan result: %s, %d, %t", name, age, member)
-	// 	}
+			t.Logf("scan result: %s, %d, %t", name, age, member)
+		}
 
-	// 	err = conn.Close(ctx)
-	// 	if err != nil {
-	// 		t.Fatal(err)
-	// 	}
-	// })
+		err = conn.Close(ctx)
+		if err != nil {
+			t.Fatal(err)
+		}
+	})
 }

--- a/writer.go
+++ b/writer.go
@@ -47,6 +47,14 @@ var ErrDataWritten = errors.New("data has already been written")
 // ErrClosedWriter is thrown when the data writer has been closed
 var ErrClosedWriter = errors.New("closed writer")
 
+// NewDataWriter constructs a new data writer using the given context and buffer.
+func NewDataWriter(ctx context.Context, writer *buffer.Writer) DataWriter {
+	return &dataWriter{
+		ctx:    ctx,
+		client: writer,
+	}
+}
+
 // dataWriter is a implementation of the DataWriter interface.
 type dataWriter struct {
 	columns Columns


### PR DESCRIPTION
This PR includes support for prepared statements and portals. The goal of this PR is to be backwards compatible with simple query handlers and provide the ability to override the parser, statements cache, and portal cache.

This PR resolves #13.