### PR TITLE
fix: emit a ready for query at the end of error messages

### DIFF
--- a/command.go
+++ b/command.go
@@ -71,7 +71,7 @@ func (srv *Server) consumeCommands(ctx context.Context, conn net.Conn, reader *b
 		}
 
 		err = srv.handleCommand(ctx, conn, t, reader, writer)
-		if err == io.EOF {
+		if errors.Is(err, io.EOF) {
 			return nil
 		}
 
@@ -435,7 +435,12 @@ func (srv *Server) handleExecute(ctx context.Context, reader *buffer.Reader, wri
 	}
 
 	srv.logger.Debug("executing", zap.String("name", name), zap.Uint32("limit", limit))
-	return srv.Portals.Execute(ctx, name, NewDataWriter(ctx, writer))
+	err = srv.Portals.Execute(ctx, name, NewDataWriter(ctx, writer))
+	if err != nil {
+		return ErrorCode(writer, err)
+	}
+
+	return nil
 }
 
 func (srv *Server) handleConnClose(ctx context.Context) error {

--- a/error_test.go
+++ b/error_test.go
@@ -1,0 +1,52 @@
+package wire
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+	"fmt"
+	"testing"
+
+	"github.com/jackc/pgx/v5"
+	"github.com/jeroenrinzema/psql-wire/codes"
+	psqlerr "github.com/jeroenrinzema/psql-wire/errors"
+	"github.com/stretchr/testify/assert"
+	"go.uber.org/zap"
+)
+
+func TestErrorCode(t *testing.T) {
+	handler := func(ctx context.Context, query string, writer DataWriter, parameters []string) error {
+		return psqlerr.WithSeverity(psqlerr.WithCode(errors.New("unimplemented feature"), codes.FeatureNotSupported), psqlerr.LevelFatal)
+	}
+
+	d, _ := zap.NewDevelopment()
+	server, err := NewServer(SimpleQuery(handler), Logger(d))
+	assert.NoError(t, err)
+
+	address := TListenAndServe(t, server)
+
+	t.Run("lib/pq", func(t *testing.T) {
+		connstr := fmt.Sprintf("host=%s port=%d sslmode=disable", address.IP, address.Port)
+		conn, err := sql.Open("postgres", connstr)
+		assert.NoError(t, err)
+
+		_, err = conn.Query("SELECT *;")
+		assert.Error(t, err)
+
+		err = conn.Close()
+		assert.NoError(t, err)
+	})
+
+	t.Run("jackc/pgx", func(t *testing.T) {
+		ctx := context.Background()
+		connstr := fmt.Sprintf("postgres://%s:%d", address.IP, address.Port)
+		conn, err := pgx.Connect(ctx, connstr)
+		assert.NoError(t, err)
+
+		_, err = conn.Query(ctx, "SELECT *;")
+		assert.Error(t, err)
+
+		err = conn.Close(ctx)
+		assert.NoError(t, err)
+	})
+}

--- a/error_test.go
+++ b/error_test.go
@@ -38,6 +38,10 @@ func TestErrorCode(t *testing.T) {
 	})
 
 	t.Run("jackc/pgx", func(t *testing.T) {
+		// TODO: we have disabled the pgx tests for now until
+		// https://github.com/jackc/pgx/discussions/1466 has been resolved
+		t.Skip()
+
 		ctx := context.Background()
 		connstr := fmt.Sprintf("postgres://%s:%d", address.IP, address.Port)
 		conn, err := pgx.Connect(ctx, connstr)

--- a/examples/error/main.go
+++ b/examples/error/main.go
@@ -1,0 +1,25 @@
+package main
+
+import (
+	"context"
+	"errors"
+	"log"
+
+	wire "github.com/jeroenrinzema/psql-wire"
+	"github.com/jeroenrinzema/psql-wire/codes"
+	psqlerr "github.com/jeroenrinzema/psql-wire/errors"
+)
+
+func main() {
+	log.Println("PostgreSQL server is up and running at [127.0.0.1:5432]")
+	wire.ListenAndServe("127.0.0.1:5432", handle)
+}
+
+func handle(ctx context.Context, query string, writer wire.DataWriter, parameters []string) error {
+	log.Println("incoming SQL query:", query)
+
+	err := errors.New("unimplemented feature")
+	err = psqlerr.WithCode(err, codes.FeatureNotSupported)
+	err = psqlerr.WithSeverity(err, psqlerr.LevelFatal)
+	return err
+}


### PR DESCRIPTION
This PR resolves the issue where a command cycle is not ended when an error is being thrown during execution.