### PR TITLE
fix: busy wait when a client disconnects

### DIFF
--- a/command.go
+++ b/command.go
@@ -86,7 +86,7 @@ func (srv *Session) consumeCommands(ctx context.Context, conn net.Conn, reader *
 func (srv *Session) consumeSingleCommand(ctx context.Context, reader *buffer.Reader, writer *buffer.Writer, conn net.Conn) error {
 	t, length, err := reader.ReadTypedMsg()
 	if err == io.EOF {
-		return nil
+		return err
 	}
 
 	// NOTE: we could recover from this scenario

--- a/wire.go
+++ b/wire.go
@@ -5,6 +5,7 @@ import (
 	"crypto/tls"
 	"errors"
 	"fmt"
+	"io"
 	"log/slog"
 	"net"
 	"sync"
@@ -114,7 +115,7 @@ func (srv *Server) Serve(listener net.Listener) error {
 		go func() {
 			ctx := context.Background()
 			err = srv.serve(ctx, conn)
-			if err != nil {
+			if err != nil && err != io.EOF {
 				srv.logger.Error("an unexpected error got returned while serving a client connection", "err", err)
 			}
 		}()


### PR DESCRIPTION
Prior to this change, when a client disconnects the reader associated with the connection will start returning `io.EOF`, which gets rewritten to `null` on https://github.com/jeroenrinzema/psql-wire/blob/main/command.go#L89, ultimately resulting in the `for` loop that calls `consumeSingleCommand` not breaking, resulting in a busy wait running in a goroutine per disconnected client.