### PR TITLE
Add support for session attributes

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,20 @@ func handler(ctx context.Context, query string) (wire.PreparedStatements, error)
 
 ---
 
+## Session Attributes
+
+You can store custom session attributes for each client connection, allowing you to track session state:
+
+```go
+// Set a session attribute
+wire.SetAttribute(ctx, "tenant_id", "tenant-123")
+
+// Get a session attribute
+tenantID, ok := wire.GetAttribute(ctx, "tenant_id")
+```
+
+---
+
 > 🚧 When wanting to debug issues and or inspect the PostgreSQL wire protocol please check out the [psql-proxy](https://github.com/cloudproud/psql-proxy) cli
 
 ## Support

--- a/command.go
+++ b/command.go
@@ -56,6 +56,7 @@ type Session struct {
 	*Server
 	Statements StatementCache
 	Portals    PortalCache
+	Attributes map[string]interface{}
 }
 
 // consumeCommands consumes incoming commands sent over the Postgres wire connection.


### PR DESCRIPTION
It's common in my app to support queries like `SET something.something = "..."` that is valid for a session.

This API makes it a first party feature of the library.