### PR TITLE
fix: nil value in parameterised query

### DIFF
--- a/command.go
+++ b/command.go
@@ -495,7 +495,7 @@ func (srv *Session) readParameters(ctx context.Context, reader *buffer.Reader) (
 
 	parameters := make([]Parameter, length)
 	for i := 0; i < int(length); i++ {
-		length, err := reader.GetUint32()
+		length, err := reader.GetInt32()
 		if err != nil {
 			return nil, err
 		}

--- a/command_test.go
+++ b/command_test.go
@@ -130,4 +130,40 @@ func TestBindMessageParameters(t *testing.T) {
 		}
 	})
 
+	t.Run("pgx nil parameter", func(t *testing.T) {
+		conn, err := pgx.Connect(ctx, connstr)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		defer conn.Close(ctx)
+
+		// changed to nil
+		rows, err := conn.Query(ctx, "SELECT $1 $2;", "John Doe", nil)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		assert.True(t, rows.Next())
+
+		var name string
+		var answer string
+
+		err = rows.Scan(&name, &answer)
+		require.NoError(t, err)
+
+		t.Logf("scan result: %s, %s", name, answer)
+
+		assert.Equal(t, name, "John Doe")
+		assert.Equal(t, answer, "")
+
+		assert.False(t, rows.Next())
+
+		rows.Close()
+
+		err = conn.Close(ctx)
+		if err != nil {
+			t.Fatal(err)
+		}
+	})
 }

--- a/pkg/buffer/reader.go
+++ b/pkg/buffer/reader.go
@@ -182,6 +182,10 @@ func (reader *Reader) GetPrepareType() (PrepareType, error) {
 
 // GetBytes returns the buffer's contents as a []byte.
 func (reader *Reader) GetBytes(n int) ([]byte, error) {
+	// NULL parameter
+	if n == -1 {
+		return nil, nil
+	}
 	if len(reader.Msg) < n {
 		return nil, NewInsufficientData(len(reader.Msg))
 	}
@@ -211,4 +215,16 @@ func (reader *Reader) GetUint32() (uint32, error) {
 	v := binary.BigEndian.Uint32(reader.Msg[:4])
 	reader.Msg = reader.Msg[4:]
 	return v, nil
+}
+
+// GetInt32 returns the buffer's contents as an int32.
+func (reader *Reader) GetInt32() (int32, error) {
+	if len(reader.Msg) < 4 {
+		return 0, NewInsufficientData(len(reader.Msg))
+	}
+
+	unsignedVal := binary.BigEndian.Uint32(reader.Msg[:4])
+	signedVal := int32(unsignedVal)
+	reader.Msg = reader.Msg[4:]
+	return signedVal, nil
 }


### PR DESCRIPTION
### Fix: Parameterized Query Null Handling
This PR resolves an "insufficient data" error encountered with parameterized queries containing NULL values. Previously, the reader.go functions incorrectly attempted to interpret the PostgreSQL protocol's -1 representation for NULL as an unsigned 32-bit integer, leading to data corruption and read failures.
This fix introduces proper handling for NULL parameters by:

Introducing GetInt32: A new function in reader.go to correctly read signed 32-bit integers from the buffer, accommodating the -1 representation for NULL.
Adding a Null Guard to GetBytes: A guard has been implemented within the GetBytes function in reader.go. This prevents further reading from the buffer when a NULL parameter is detected, as no additional data is provided for NULL values.

Key Changes:

reader.go:
- Added GetInt32 function.
- Modified GetBytes to include a null parameter guard.


Test Suite:
- Added a new test case that sends a parameterised SELECT statement with NULL values to ensure correct behavior.


This improvement ensures robust and accurate processing of parameterised queries, particularly when dealing with NULL data.