### PR TITLE
Return error when cleartext auth fails, don't announce server is ready

### DIFF
--- a/auth.go
+++ b/auth.go
@@ -73,7 +73,12 @@ func ClearTextPassword(validate func(ctx context.Context, database, username, pa
 		}
 
 		if !valid {
-			return ctx, ErrorCode(writer, pgerror.WithCode(errors.New("invalid username/password"), codes.InvalidPassword))
+			authErr := pgerror.WithCode(errors.New("invalid username/password"), codes.InvalidPassword)
+			err = ErrorCode(writer, authErr)
+			if err != nil {
+				return ctx, err
+			}
+			return ctx, authErr
 		}
 
 		return ctx, writeAuthType(writer, authOK)

--- a/auth_test.go
+++ b/auth_test.go
@@ -76,3 +76,38 @@ func TestClearTextPassword(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, ctx, out)
 }
+
+func TestClearTextPasswordIncorrect(t *testing.T) {
+	correctPassword := "correct-password"
+	incorrectPassword := "wrong-password"
+
+	input := bytes.NewBuffer([]byte{})
+	incoming := buffer.NewWriter(slogt.New(t), input)
+
+	// Client sends the incorrect password
+	incoming.Start(types.ServerMessage(types.ClientPassword))
+	incoming.AddString(incorrectPassword)
+	incoming.AddNullTerminate()
+	incoming.End() //nolint:errcheck
+
+	validate := func(ctx context.Context, database, username, password string) (context.Context, bool, error) {
+		// Only accept the correct password
+		if password == correctPassword {
+			return ctx, true, nil
+		}
+		return ctx, false, nil
+	}
+
+	sink := bytes.NewBuffer([]byte{})
+
+	ctx := context.Background()
+	reader := buffer.NewReader(slogt.New(t), input, buffer.DefaultBufferSize)
+	writer := buffer.NewWriter(slogt.New(t), sink)
+
+	server := &Server{logger: slogt.New(t), Auth: ClearTextPassword(validate)}
+	_, err := server.handleAuth(ctx, reader, writer)
+
+	// Authentication should fail with an error
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "invalid username/password")
+}

--- a/error.go
+++ b/error.go
@@ -1,6 +1,7 @@
 package wire
 
 import (
+	"github.com/jeroenrinzema/psql-wire/codes"
 	psqlerr "github.com/jeroenrinzema/psql-wire/errors"
 	"github.com/jeroenrinzema/psql-wire/pkg/buffer"
 	"github.com/jeroenrinzema/psql-wire/pkg/types"
@@ -76,6 +77,11 @@ func ErrorCode(writer *buffer.Writer, err error) error {
 	}
 
 	// NOTE: we are writing a ready for query message to indicate the end of a
-	// command cycle.
+	// command cycle. However, for authentication failures, we skip this
+	// because the connection will be terminated.
+	if desc.Code == codes.InvalidPassword {
+		return nil
+	}
+
 	return readyForQuery(writer, types.ServerIdle)
 }


### PR DESCRIPTION
This PR fixes an issue when using the `ClearTextPassword` auth strategy and an invalid password is provided by the client.

The current behaviour does not close the connection and instead `wire` will continue to handle the request, set server parameters and create a session. This is because the return when a password is invalid is `ErrorCode(writer, pgerror.WithCode(errors.New("invalid username/password"), codes.InvalidPassword))` and this will write that the connection is ready (and thus return `nil`).

https://github.com/jeroenrinzema/psql-wire/blob/274e44e1a97249392080a5b1a8dd3b0ab8a8cb26/error.go#L78-L80

Without the `err` propagating, `wire` won't abort and it'll continue to process the request as if the authentication was successful:

https://github.com/jeroenrinzema/psql-wire/blob/274e44e1a97249392080a5b1a8dd3b0ab8a8cb26/wire.go#L200-L215 

This can be observed looking at this output from [psql-proxy](https://github.com/cloudproud/psql-proxy) which shows even though an error was returned, the code continued to execute and set the server parameters.

<img width="1119" alt="Screenshot 2025-06-24 at 3 00 31 pm" src="https://github.com/user-attachments/assets/d4041ddb-a0fa-4366-b882-4d019c14c7e7" />

This PR does two main things:

1. If the `err` passed to `ErrorCode` is `codes.InvalidPassword`, don't write that the server is ready.
2. Don't return the result of `ErrorCode` from `ClearTextPassword`, return the actual error instead.

Both of these changes in tandem will result in an error being returned to the client and the client being closed (as the err is propagated up). I've added some tests that should help prove this change works, but please suggest alternative solutions as I don't have a lot of context.

These changes result in the following `psql-proxy` output which shows the interaction ending after the invalid password error is returned; there are no server parameters set and interestingly (but perhaps expected?) no unexpected errors from the connection being reset/broken pipe:

<img width="693" alt="Screenshot 2025-06-24 at 4 30 24 pm" src="https://github.com/user-attachments/assets/62098083-baf2-475c-826c-55d9aa908d82" />
