### PR TITLE
feature: copy-in csv data from stdin

### DIFF
--- a/copy.go
+++ b/copy.go
@@ -1,8 +1,10 @@
 package wire
 
 import (
+	"bufio"
 	"bytes"
 	"context"
+	"encoding/csv"
 	"errors"
 	"fmt"
 	"io"
@@ -187,4 +189,127 @@ func (r *BinaryCopyReader) Read(ctx context.Context) (_ []any, err error) {
 	}
 
 	return row, nil
+}
+
+// read text data
+
+type TextCopyReader struct {
+	typeMap    *pgtype.Map
+	reader     *CopyReader
+	scanners   []Scanner
+	csvReader  *csv.Reader
+	buffer     *bytes.Buffer
+	bufScanner *bufio.Scanner
+	nullValue  string // PostgreSQL NULL value string (default empty)
+}
+
+func NewTextColumnReader(ctx context.Context, copy *CopyReader) (_ *TextCopyReader, err error) {
+	tm := TypeMap(ctx)
+	if tm == nil {
+		return nil, errors.New("postgres connection info has not been defined inside the given context")
+	}
+
+	scanners := make([]Scanner, len(copy.columns))
+	for index, column := range copy.columns {
+		scanners[index], err = NewScanner(tm, column, TextFormat)
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	csvReaderBuffer := &bytes.Buffer{}
+	csvReader := csv.NewReader(csvReaderBuffer)
+	csvReader.Comma = ','
+	csvReader.TrimLeadingSpace = false
+	csvReader.LazyQuotes = true // Handle non-standard quoting
+
+	reader := &TextCopyReader{
+		typeMap:    tm,
+		reader:     copy,
+		scanners:   scanners,
+		csvReader:  csvReader,
+		buffer:     csvReaderBuffer,
+		bufScanner: bufio.NewScanner(csvReaderBuffer),
+		nullValue:  "", // Default NULL value is empty string
+	}
+
+	return reader, nil
+}
+
+// Read reads a single row from the copy-in stream. The read row is returned as a
+// slice of any values. If the end of the copy-in stream is reached, an io.EOF error
+// is returned.
+func (r *TextCopyReader) Read(ctx context.Context) (_ []any, err error) {
+	if ctx.Err() != nil {
+		return nil, ctx.Err()
+	}
+
+	for {
+		// Try to read a CSV record from the current buffer
+		record, err := r.csvReader.Read()
+		if err == io.EOF {
+			// CSV reader hit EOF, need more data from copy stream
+			err = r.reader.Read()
+			if err == io.EOF {
+				// End of copy stream, no more data
+				return nil, io.EOF
+			}
+			if err != nil {
+				return nil, err
+			}
+
+			// Process PostgreSQL CSV escape sequences before adding to buffer
+			processedData := r.preprocessPostgreSQLCSV(r.reader.Msg)
+			r.buffer.Write(processedData)
+
+			// Clear the message after copying to buffer
+			r.reader.Msg = r.reader.Msg[:0]
+
+			// Continue loop to try reading CSV record again
+			continue
+		} else if err != nil {
+			return nil, fmt.Errorf("CSV parsing error: %w", err)
+		}
+
+		// Successfully read a CSV record, convert to row
+		return r.convertRecord(record)
+	}
+}
+
+// convertRecord converts a CSV record to a slice of typed values
+func (r *TextCopyReader) convertRecord(record []string) ([]any, error) {
+	if len(record) != len(r.scanners) {
+		return nil, fmt.Errorf("CSV record has %d fields, expected %d", len(record), len(r.scanners))
+	}
+
+	row := make([]any, len(record))
+	for i, field := range record {
+		// Handle NULL values - check both empty string (default) and custom NULL value
+		if field == r.nullValue || (r.nullValue == "" && field == "") {
+			row[i] = nil
+			continue
+		}
+
+		// Convert string field to appropriate type using scanner
+		value, err := r.scanners[i]([]byte(field))
+		if err != nil {
+			return nil, fmt.Errorf("failed to scan field %d: %w", i, err)
+		}
+		row[i] = value
+	}
+
+	return row, nil
+}
+
+// preprocessPostgreSQLCSV converts PostgreSQL CSV escape sequences to RFC 4180 format
+// PostgreSQL uses \ as escape character, but Go's csv package expects "" for quote escaping
+func (r *TextCopyReader) preprocessPostgreSQLCSV(data []byte) []byte {
+	// Convert PostgreSQL \" to "" for RFC 4180 compliance
+	result := bytes.ReplaceAll(data, []byte(`\"`), []byte(`""`))
+	return result
+}
+
+// SetNullValue sets the string that represents NULL values in the CSV
+func (r *TextCopyReader) SetNullValue(nullValue string) {
+	r.nullValue = nullValue
 }

--- a/copy.go
+++ b/copy.go
@@ -267,10 +267,10 @@ func (r *TextCopyReader) Read(ctx context.Context) (_ []any, err error) {
 
 			// Continue loop to try reading CSV record again
 			continue
+		}
 		if err != nil && err != io.EOF {
 			return nil, fmt.Errorf("CSV parsing error: %w", err)
 		}
-
 		// Successfully read a CSV record, convert to row
 		return r.convertRecord(record)
 	}

--- a/copy.go
+++ b/copy.go
@@ -203,7 +203,7 @@ type TextCopyReader struct {
 	nullValue  string // PostgreSQL NULL value string (default empty)
 }
 
-func NewTextColumnReader(ctx context.Context, copy *CopyReader) (_ *TextCopyReader, err error) {
+func NewTextColumnReader(ctx context.Context, copy *CopyReader, separator rune) (_ *TextCopyReader, err error) {
 	tm := TypeMap(ctx)
 	if tm == nil {
 		return nil, errors.New("postgres connection info has not been defined inside the given context")
@@ -219,7 +219,7 @@ func NewTextColumnReader(ctx context.Context, copy *CopyReader) (_ *TextCopyRead
 
 	csvReaderBuffer := &bytes.Buffer{}
 	csvReader := csv.NewReader(csvReaderBuffer)
-	csvReader.Comma = ','
+	csvReader.Comma = separator
 	csvReader.TrimLeadingSpace = false
 	csvReader.LazyQuotes = true // Handle non-standard quoting
 

--- a/copy_test.go
+++ b/copy_test.go
@@ -52,7 +52,10 @@ func TestCopyReaderText(t *testing.T) {
 			}
 
 			var length int
-			reader, err := NewTextColumnReader(ctx, copyText, ',')
+			reader, err := NewTextColumnReader(ctx, copyText, TextCopyReaderOptions{
+				separator: ',',
+				nullValue: "",
+			})
 			if err != nil {
 				return err
 			}
@@ -157,13 +160,13 @@ func TestCopyReaderTextNullAndEscape(t *testing.T) {
 			}
 
 			var length int
-			reader, err := NewTextColumnReader(ctx, copyText, ',')
+			reader, err := NewTextColumnReader(ctx, copyText, TextCopyReaderOptions{
+				separator: ',',
+				nullValue: "attNULL",
+			})
 			if err != nil {
 				return err
 			}
-
-			// Set NULL value for this test
-			reader.SetNullValue("attNULL")
 
 			for {
 				columns, err := reader.Read(ctx)

--- a/copy_test.go
+++ b/copy_test.go
@@ -1,15 +1,18 @@
 package wire
 
 import (
+	"bytes"
 	"context"
+	"encoding/csv"
 	"fmt"
-	"github.com/jackc/pgx/v5"
-	"github.com/lib/pq/oid"
-	"github.com/neilotoole/slogt"
 	"io"
 	"log"
 	"os"
 	"testing"
+
+	"github.com/jackc/pgx/v5"
+	"github.com/lib/pq/oid"
+	"github.com/neilotoole/slogt"
 )
 
 func TestCopyReaderText(t *testing.T) {
@@ -52,10 +55,12 @@ func TestCopyReaderText(t *testing.T) {
 			}
 
 			var length int
-			reader, err := NewTextColumnReader(ctx, copyText, TextCopyReaderOptions{
-				separator: ',',
-				nullValue: "",
-			})
+			csvReaderBuffer := &bytes.Buffer{}
+			csvReader := csv.NewReader(csvReaderBuffer)
+			csvReader.Comma = ','
+			csvReader.TrimLeadingSpace = false
+			csvReader.LazyQuotes = true
+			reader, err := NewTextColumnReader(ctx, copyText, csvReader, csvReaderBuffer, "")
 			if err != nil {
 				return err
 			}
@@ -160,10 +165,12 @@ func TestCopyReaderTextNullAndEscape(t *testing.T) {
 			}
 
 			var length int
-			reader, err := NewTextColumnReader(ctx, copyText, TextCopyReaderOptions{
-				separator: ',',
-				nullValue: "attNULL",
-			})
+			csvReaderBuffer := &bytes.Buffer{}
+			csvReader := csv.NewReader(csvReaderBuffer)
+			csvReader.Comma = ','
+			csvReader.TrimLeadingSpace = false
+			csvReader.LazyQuotes = true
+			reader, err := NewTextColumnReader(ctx, copyText, csvReader, csvReaderBuffer, "attNULL")
 			if err != nil {
 				return err
 			}

--- a/copy_test.go
+++ b/copy_test.go
@@ -52,7 +52,7 @@ func TestCopyReaderText(t *testing.T) {
 			}
 
 			var length int
-			reader, err := NewTextColumnReader(ctx, copyText)
+			reader, err := NewTextColumnReader(ctx, copyText, ',')
 			if err != nil {
 				return err
 			}
@@ -157,7 +157,7 @@ func TestCopyReaderTextNullAndEscape(t *testing.T) {
 			}
 
 			var length int
-			reader, err := NewTextColumnReader(ctx, copyText)
+			reader, err := NewTextColumnReader(ctx, copyText, ',')
 			if err != nil {
 				return err
 			}

--- a/copy_test.go
+++ b/copy_test.go
@@ -1,0 +1,220 @@
+package wire
+
+import (
+	"context"
+	"fmt"
+	"github.com/jackc/pgx/v5"
+	"github.com/lib/pq/oid"
+	"github.com/neilotoole/slogt"
+	"io"
+	"log"
+	"os"
+	"testing"
+)
+
+func TestCopyReaderText(t *testing.T) {
+	table := Columns{
+		{
+			Table: 0,
+			Name:  "id",
+			Oid:   oid.T_int4,
+			Width: 4,
+		},
+		{
+			Table: 0,
+			Name:  "name",
+			Oid:   oid.T_text,
+			Width: 256,
+		},
+		{
+			Table: 0,
+			Name:  "member",
+			Oid:   oid.T_bool,
+			Width: 1,
+		},
+		{
+			Table: 0,
+			Name:  "age",
+			Oid:   oid.T_int4,
+			Width: 1,
+		},
+	}
+
+	handler := func(ctx context.Context, query string) (PreparedStatements, error) {
+		log.Println("incoming SQL query:", query)
+
+		handle := func(ctx context.Context, writer DataWriter, parameters []Parameter) error {
+			log.Println("copying data")
+
+			copyText, err := writer.CopyIn(TextFormat)
+			if err != nil {
+				return err
+			}
+
+			var length int
+			reader, err := NewTextColumnReader(ctx, copyText)
+			if err != nil {
+				return err
+			}
+
+			for {
+				columns, err := reader.Read(ctx)
+				if err == io.EOF {
+					break
+				}
+
+				if err != nil {
+					return err
+				}
+
+				t.Logf("received columns: %+v", columns)
+				length++
+			}
+
+			return writer.Complete(fmt.Sprintf("COPY %d", length))
+		}
+
+		return Prepared(NewStatement(handle, WithColumns(table))), nil
+	}
+
+	server, err := NewServer(handler, Logger(slogt.New(t)))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	address := TListenAndServe(t, server)
+
+	ctx := context.Background()
+	connStr := fmt.Sprintf("postgres://%s:%d", address.IP, address.Port)
+
+	t.Run("CopyInStmtFromStdinText", func(t *testing.T) {
+		conn, err := pgx.Connect(ctx, connStr)
+		if err != nil {
+			t.Fatal(err)
+		}
+		defer conn.Close(ctx)
+
+		file, err := os.Open("jedis.csv")
+		if err != nil {
+			log.Fatalf("failed to open CSV file: %s", err.Error())
+		}
+
+		query := `COPY "public"."jedis" FROM STDIN WITH DELIMITER ',' CSV`
+
+		_, err = conn.PgConn().CopyFrom(
+			ctx,
+			file,
+			query,
+		)
+		if err != nil {
+			t.Fatalf("copy stmt failed: %s \n", err.Error())
+		}
+	})
+}
+
+func TestCopyReaderTextNullAndEscape(t *testing.T) {
+	table := Columns{
+		{
+			Table: 0,
+			Name:  "id",
+			Oid:   oid.T_int4,
+			Width: 4,
+		},
+		{
+			Table: 0,
+			Name:  "name",
+			Oid:   oid.T_text,
+			Width: 256,
+		},
+		{
+			Table: 0,
+			Name:  "member",
+			Oid:   oid.T_bool,
+			Width: 1,
+		},
+		{
+			Table: 0,
+			Name:  "age",
+			Oid:   oid.T_int4,
+			Width: 1,
+		},
+		{
+			Table: 0,
+			Name:  "description",
+			Oid:   oid.T_text,
+		},
+	}
+
+	handler := func(ctx context.Context, query string) (PreparedStatements, error) {
+		log.Println("incoming SQL query:", query)
+
+		handle := func(ctx context.Context, writer DataWriter, parameters []Parameter) error {
+			log.Println("copying data")
+
+			copyText, err := writer.CopyIn(TextFormat)
+			if err != nil {
+				return err
+			}
+
+			var length int
+			reader, err := NewTextColumnReader(ctx, copyText)
+			if err != nil {
+				return err
+			}
+
+			// Set NULL value for this test
+			reader.SetNullValue("attNULL")
+
+			for {
+				columns, err := reader.Read(ctx)
+				if err == io.EOF {
+					break
+				}
+
+				if err != nil {
+					return err
+				}
+
+				t.Logf("received columns: %+v", columns)
+				length++
+			}
+
+			return writer.Complete(fmt.Sprintf("COPY %d", length))
+		}
+
+		return Prepared(NewStatement(handle, WithColumns(table))), nil
+	}
+
+	server, err := NewServer(handler, Logger(slogt.New(t)))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	address := TListenAndServe(t, server)
+
+	ctx := context.Background()
+	connStr := fmt.Sprintf("postgres://%s:%d", address.IP, address.Port)
+
+	t.Run("CopyInStmtFromStdinTextNullAndEscape", func(t *testing.T) {
+		conn, err := pgx.Connect(ctx, connStr)
+		if err != nil {
+			t.Fatal(err)
+		}
+		defer conn.Close(ctx)
+
+		file, err := os.Open("jedis_null_escape.csv")
+		if err != nil {
+			log.Fatalf("failed to open CSV file: %s", err.Error())
+		}
+		query := `COPY "public"."jedis" FROM STDIN WITH DELIMITER ',' CSV NULL 'attNULL' ESCAPE '\'`
+
+		_, err = conn.PgConn().CopyFrom(
+			ctx,
+			file,
+			query,
+		)
+		if err != nil {
+			t.Fatalf("copy stmt failed: %s \n", err.Error())
+		}
+	})
+}

--- a/jedis.csv
+++ b/jedis.csv
@@ -1,0 +1,2 @@
+1,obiwan,true,32
+2,anakin,true,25

--- a/jedis_null_escape.csv
+++ b/jedis_null_escape.csv
@@ -1,0 +1,3 @@
+1,obiwan,true,32,"A brave jedi. This is a \"special\" description."
+2,anakin,true,25,"he is dangerous"
+3,asoka,attNULL,19,attNULL


### PR DESCRIPTION
**feat: Support CSV data copy-in from stdin**

**Problem:**
Currently, our copy-in functionality for binary data doesn't directly support structured text formats like CSV from `stdin`, making it cumbersome to import CSV data programmatically or via shell pipelines.

**Solution:**
This PR introduces the ability to copy CSV data directly from `stdin`, building upon our existing binary data ingestion capabilities.

**Key Changes:**

*   **`NewTextColumnReader` Function:** A new reader function has been added to facilitate the parsing of CSV data.
    *   It initializes a `bufio.Scanner` to efficiently read text lines.
    *   It utilizes the `encoding/csv` package to robustly parse CSV records within its `Read` method.
    *   It offers configurable options for specifying custom null values and escape sequences, providing flexibility for diverse CSV datasets.
*   **Integration with Handler:** The `NewTextColumnReader` can now be referenced and used within the handler function to process incoming CSV streams.
* Added copy_test and csv test data

**Benefits:**

*   Simplifies the process of importing CSV data from `stdin`.
*   Enhances the flexibility and utility of our copy-in feature for text-based structured data.
*   Provides robust CSV parsing with configurable options.