### PR TITLE
Implement cache cleanup behaviour

### DIFF
--- a/cache.go
+++ b/cache.go
@@ -60,7 +60,18 @@ func (cache *DefaultStatementCache) Get(ctx context.Context, name string) (*Stat
 	return stmt, nil
 }
 
-func (cache *DefaultStatementCache) Close() {}
+func (cache *DefaultStatementCache) Delete(ctx context.Context, name string) error {
+	cache.mu.Lock()
+	defer cache.mu.Unlock()
+	delete(cache.statements, name)
+	return nil
+}
+
+func (cache *DefaultStatementCache) Close() {
+	cache.mu.Lock()
+	defer cache.mu.Unlock()
+	clear(cache.statements)
+}
 
 type Portal struct {
 	statement  *Statement
@@ -118,14 +129,18 @@ func (cache *DefaultPortalCache) Execute(ctx context.Context, name string, limit
 		}
 	}()
 
-	cache.mu.Lock()
-	defer cache.mu.Unlock()
-
+	// Look up the portal under the lock, then release before executing.
+	// The handler may call back into the cache so we must make sure we don't
+	// hold the lock for the execute duration. e.g. a handler for DEALLOCATE
+	// may call back into the cache to delete a portal.
+	cache.mu.RLock()
 	if cache.portals == nil {
+		cache.mu.RUnlock()
 		return nil
 	}
 
 	portal, has := cache.portals[name]
+	cache.mu.RUnlock()
 	if !has {
 		return nil
 	}
@@ -134,4 +149,26 @@ func (cache *DefaultPortalCache) Execute(ctx context.Context, name string, limit
 	return portal.statement.fn(ctx, NewDataWriter(ctx, session, portal.statement.columns, portal.formats, limit, reader, writer), portal.parameters)
 }
 
-func (cache *DefaultPortalCache) Close() {}
+func (cache *DefaultPortalCache) Delete(ctx context.Context, name string) error {
+	cache.mu.Lock()
+	defer cache.mu.Unlock()
+	delete(cache.portals, name)
+	return nil
+}
+
+func (cache *DefaultPortalCache) DeleteByStatement(ctx context.Context, stmt *Statement) error {
+	cache.mu.Lock()
+	defer cache.mu.Unlock()
+	for name, portal := range cache.portals {
+		if portal.statement == stmt {
+			delete(cache.portals, name)
+		}
+	}
+	return nil
+}
+
+func (cache *DefaultPortalCache) Close() {
+	cache.mu.Lock()
+	defer cache.mu.Unlock()
+	clear(cache.portals)
+}

--- a/command.go
+++ b/command.go
@@ -63,7 +63,7 @@ type Session struct {
 
 	// inExtendedQuery is true when the current message being handled is an
 	// extended query protocol message (Parse, Bind, Describe, Execute, Close,
-	// Flush, Sync). This lets Session.ErrorCode behave correctly for both
+	// Flush, Sync). This lets Session.WriteError behave correctly for both
 	// protocols.
 	inExtendedQuery bool
 
@@ -371,6 +371,18 @@ func (srv *Session) handleParse(ctx context.Context, reader *buffer.Reader, writ
 		// Specifies the object ID of the parameter data type. Placing a zero here
 		// is equivalent to leaving the type unspecified.
 		// `reader.GetUint32()`
+	}
+
+	existing, err := srv.Statements.Get(ctx, name)
+	if err != nil {
+		if srv.ParallelPipeline.Enabled {
+			return srv.drainQueueAndWriteError(ctx, writer, err)
+		}
+		return srv.WriteError(writer, err)
+	}
+
+	if existing != nil {
+		srv.Portals.DeleteByStatement(ctx, existing) //nolint:errcheck
 	}
 
 	if srv.ParallelPipeline.Enabled {
@@ -719,7 +731,18 @@ func (srv *Session) handleClose(ctx context.Context, reader *buffer.Reader, writ
 		return err
 	}
 
-	srv.logger.Debug("incoming close request", slog.String("type", string(d[0])), slog.String("name", name))
+	srv.logger.Debug("incoming close request", slog.String("type", types.CloseMessage(d[0]).String()), slog.String("name", name))
+
+	switch types.CloseMessage(d[0]) {
+	case types.CloseStatement:
+		stmt, _ := srv.Statements.Get(ctx, name)
+		srv.Statements.Delete(ctx, name) //nolint:errcheck
+		if stmt != nil {
+			srv.Portals.DeleteByStatement(ctx, stmt) //nolint:errcheck
+		}
+	case types.ClosePortal:
+		srv.Portals.Delete(ctx, name) //nolint:errcheck
+	}
 
 	if srv.ParallelPipeline.Enabled {
 		srv.ResponseQueue.Enqueue(NewCloseCompleteEvent())

--- a/command_close_test.go
+++ b/command_close_test.go
@@ -13,33 +13,86 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestHandleClose_Statement(t *testing.T) {
+func TestHandleClose_StatementRemovesFromCache(t *testing.T) {
 	t.Parallel()
 
 	ctx := context.Background()
 	logger := slogt.New(t)
 
+	stmtCache := &DefaultStatementCache{}
+	portalCache := &DefaultPortalCache{}
+
+	stmt := &PreparedStatement{
+		fn: func(ctx context.Context, writer DataWriter, parameters []Parameter) error {
+			return writer.Complete("OK")
+		},
+	}
+
+	err := stmtCache.Set(ctx, "stmt1", stmt)
+	require.NoError(t, err)
+
+	// Bind two portals to the same statement
+	cached, err := stmtCache.Get(ctx, "stmt1")
+	require.NoError(t, err)
+	require.NotNil(t, cached)
+
+	err = portalCache.Bind(ctx, "p1", cached, nil, nil)
+	require.NoError(t, err)
+	err = portalCache.Bind(ctx, "p2", cached, nil, nil)
+	require.NoError(t, err)
+
+	// Bind a portal to a different statement so we can verify it survives
+	otherStmt := &PreparedStatement{
+		fn: func(ctx context.Context, writer DataWriter, parameters []Parameter) error {
+			return writer.Complete("OK")
+		},
+	}
+	err = stmtCache.Set(ctx, "other", otherStmt)
+	require.NoError(t, err)
+	otherCached, err := stmtCache.Get(ctx, "other")
+	require.NoError(t, err)
+	err = portalCache.Bind(ctx, "p3", otherCached, nil, nil)
+	require.NoError(t, err)
+
 	session := &Session{
 		Server:     &Server{logger: logger},
-		Statements: &DefaultStatementCache{},
-		Portals:    &DefaultPortalCache{},
+		Statements: stmtCache,
+		Portals:    portalCache,
 	}
 
 	outBuf := &bytes.Buffer{}
 	writer := buffer.NewWriter(logger, outBuf)
 
-	reader := mock.NewCloseReader(t, logger, 'S', "stmt1")
-
-	err := session.handleClose(ctx, reader, writer)
+	err = session.handleClose(ctx, mock.NewCloseReader(t, logger, types.CloseStatement, "stmt1"), writer)
 	require.NoError(t, err)
 
+	// Statement should be removed
+	got, err := stmtCache.Get(ctx, "stmt1")
+	require.NoError(t, err)
+	assert.Nil(t, got)
+
+	// Portals bound to the closed statement should be removed
+	p1, err := portalCache.Get(ctx, "p1")
+	require.NoError(t, err)
+	assert.Nil(t, p1)
+
+	p2, err := portalCache.Get(ctx, "p2")
+	require.NoError(t, err)
+	assert.Nil(t, p2)
+
+	// Portal bound to a different statement should still exist
+	p3, err := portalCache.Get(ctx, "p3")
+	require.NoError(t, err)
+	assert.NotNil(t, p3)
+
+	// CloseComplete should still be sent
 	responseReader := mock.NewReader(t, outBuf)
 	msgType, _, err := responseReader.ReadTypedMsg()
 	require.NoError(t, err)
 	assert.Equal(t, types.ServerCloseComplete, msgType)
 }
 
-func TestHandleClose_Portal(t *testing.T) {
+func TestHandleClose_NonexistentNameSendsCloseComplete(t *testing.T) {
 	t.Parallel()
 
 	ctx := context.Background()
@@ -54,10 +107,70 @@ func TestHandleClose_Portal(t *testing.T) {
 	outBuf := &bytes.Buffer{}
 	writer := buffer.NewWriter(logger, outBuf)
 
-	reader := mock.NewCloseReader(t, logger, 'P', "portal1")
-
-	err := session.handleClose(ctx, reader, writer)
+	// Close a statement that doesn't exist
+	err := session.handleClose(ctx, mock.NewCloseReader(t, logger, types.CloseStatement, "nonexistent"), writer)
 	require.NoError(t, err)
+
+	responseReader := mock.NewReader(t, outBuf)
+	msgType, _, err := responseReader.ReadTypedMsg()
+	require.NoError(t, err)
+	assert.Equal(t, types.ServerCloseComplete, msgType)
+
+	// Close a portal that doesn't exist
+	outBuf.Reset()
+	err = session.handleClose(ctx, mock.NewCloseReader(t, logger, types.ClosePortal, "nonexistent"), writer)
+	require.NoError(t, err)
+
+	responseReader = mock.NewReader(t, outBuf)
+	msgType, _, err = responseReader.ReadTypedMsg()
+	require.NoError(t, err)
+	assert.Equal(t, types.ServerCloseComplete, msgType)
+}
+
+func TestHandleClose_PortalRemovesFromCache(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	logger := slogt.New(t)
+
+	stmtCache := &DefaultStatementCache{}
+	portalCache := &DefaultPortalCache{}
+
+	stmt := &PreparedStatement{
+		fn: func(ctx context.Context, writer DataWriter, parameters []Parameter) error {
+			return writer.Complete("OK")
+		},
+	}
+
+	err := stmtCache.Set(ctx, "stmt1", stmt)
+	require.NoError(t, err)
+	cached, err := stmtCache.Get(ctx, "stmt1")
+	require.NoError(t, err)
+
+	err = portalCache.Bind(ctx, "portal1", cached, nil, nil)
+	require.NoError(t, err)
+
+	session := &Session{
+		Server:     &Server{logger: logger},
+		Statements: stmtCache,
+		Portals:    portalCache,
+	}
+
+	outBuf := &bytes.Buffer{}
+	writer := buffer.NewWriter(logger, outBuf)
+
+	err = session.handleClose(ctx, mock.NewCloseReader(t, logger, types.ClosePortal, "portal1"), writer)
+	require.NoError(t, err)
+
+	// Portal should be removed
+	portal, err := portalCache.Get(ctx, "portal1")
+	require.NoError(t, err)
+	assert.Nil(t, portal)
+
+	// Statement should still exist
+	got, err := stmtCache.Get(ctx, "stmt1")
+	require.NoError(t, err)
+	assert.NotNil(t, got)
 
 	responseReader := mock.NewReader(t, outBuf)
 	msgType, _, err := responseReader.ReadTypedMsg()
@@ -82,7 +195,7 @@ func TestHandleClose_ParallelPipeline(t *testing.T) {
 	outBuf := &bytes.Buffer{}
 	writer := buffer.NewWriter(logger, outBuf)
 
-	reader := mock.NewCloseReader(t, logger, 'S', "stmt1")
+	reader := mock.NewCloseReader(t, logger, types.CloseStatement, "stmt1")
 
 	err := session.handleClose(ctx, reader, writer)
 	require.NoError(t, err)

--- a/command_parse_test.go
+++ b/command_parse_test.go
@@ -148,3 +148,71 @@ func TestHandleParse_ParallelPipeline_Error(t *testing.T) {
 	require.NoError(t, err)
 	assert.Equal(t, types.ServerErrorResponse, msgType)
 }
+
+func TestHandleParse_OverwriteRemovesRelatedPortals(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	typeMap := pgtype.NewMap()
+	ctx = setTypeInfo(ctx, typeMap)
+	logger := slogt.New(t)
+
+	mockParse := func(ctx context.Context, query string) (PreparedStatements, error) {
+		return PreparedStatements{NewStatement(
+			func(ctx context.Context, writer DataWriter, parameters []Parameter) error {
+				return writer.Complete("SELECT 1")
+			},
+		)}, nil
+	}
+
+	portalCache := &DefaultPortalCache{}
+	session := &Session{
+		Server: &Server{
+			logger: logger,
+			parse:  mockParse,
+		},
+		Statements: &DefaultStatementCache{},
+		Portals:    portalCache,
+	}
+
+	outBuf := &bytes.Buffer{}
+	writer := buffer.NewWriter(logger, outBuf)
+
+	// Parse a statement and bind two portals to it
+	err := session.handleParse(ctx, mock.NewParseReader(t, logger, "s1", "SELECT 1", 0), writer)
+	require.NoError(t, err)
+	err = session.handleBind(ctx, mock.NewBindReader(t, logger, "p1", "s1", 0, 0, 0), writer)
+	require.NoError(t, err)
+	err = session.handleBind(ctx, mock.NewBindReader(t, logger, "p2", "s1", 0, 0, 0), writer)
+	require.NoError(t, err)
+
+	// Parse a different statement and bind a portal to it (should survive)
+	err = session.handleParse(ctx, mock.NewParseReader(t, logger, "s2", "SELECT 2", 0), writer)
+	require.NoError(t, err)
+	err = session.handleBind(ctx, mock.NewBindReader(t, logger, "p3", "s2", 0, 0, 0), writer)
+	require.NoError(t, err)
+
+	// Verify all portals exist
+	for _, name := range []string{"p1", "p2", "p3"} {
+		portal, err := portalCache.Get(ctx, name)
+		require.NoError(t, err)
+		require.NotNil(t, portal, "portal %s should exist before overwrite", name)
+	}
+
+	// Re-parse s1 — portals p1 and p2 should be removed
+	err = session.handleParse(ctx, mock.NewParseReader(t, logger, "s1", "SELECT 3", 0), writer)
+	require.NoError(t, err)
+
+	p1, err := portalCache.Get(ctx, "p1")
+	require.NoError(t, err)
+	assert.Nil(t, p1, "portal bound to overwritten statement should be removed")
+
+	p2, err := portalCache.Get(ctx, "p2")
+	require.NoError(t, err)
+	assert.Nil(t, p2, "portal bound to overwritten statement should be removed")
+
+	// p3 is bound to s2, should still exist
+	p3, err := portalCache.Get(ctx, "p3")
+	require.NoError(t, err)
+	assert.NotNil(t, p3, "portal bound to a different statement should survive")
+}

--- a/error_test.go
+++ b/error_test.go
@@ -287,8 +287,14 @@ func TestDiscardUntilSync(t *testing.T) {
 	assert.False(t, session.discardUntilSync)
 
 	// Second cycle: Close, Sync (deallocate the failed statement)
-	err = session.handleClose(ctx, mock.NewCloseReader(t, logger, 'S', "stmt1"), writer)
+	err = session.handleClose(ctx, mock.NewCloseReader(t, logger, types.CloseStatement, "stmt1"), writer)
 	require.NoError(t, err)
+
+	// The statement should be removed from the cache after Close
+	stmt, err := session.Statements.Get(ctx, "stmt1")
+	require.NoError(t, err)
+	assert.Nil(t, stmt, "statement should be removed from cache after Close")
+
 	err = session.handleSync(ctx, writer)
 	require.NoError(t, err)
 

--- a/options.go
+++ b/options.go
@@ -85,6 +85,9 @@ type StatementCache interface {
 	// Get attempts to get the prepared statement for the given name. An error
 	// is returned when no statement has been found.
 	Get(ctx context.Context, name string) (*Statement, error)
+	// Delete removes the prepared statement with the given name. Deleting a
+	// nonexistent name is not an error.
+	Delete(ctx context.Context, name string) error
 	// Close is called at the end of a connection. Close releases all resources
 	// held by the statement cache.
 	Close()
@@ -101,6 +104,12 @@ type PortalCache interface {
 	Get(ctx context.Context, name string) (*Portal, error)
 	// Execute executes the prepared statement with the given name and parameters.
 	Execute(ctx context.Context, name string, limit Limit, reader *buffer.Reader, writer *buffer.Writer) error
+	// Delete removes the portal with the given name. Deleting a nonexistent
+	// name is not an error.
+	Delete(ctx context.Context, name string) error
+	// DeleteByStatement removes all portals that were bound to the given
+	// statement.
+	DeleteByStatement(ctx context.Context, stmt *Statement) error
 	// Close is called at the end of a connection. Close releases all resources
 	// held by the portal cache.
 	Close()

--- a/pkg/mock/buffer.go
+++ b/pkg/mock/buffer.go
@@ -123,14 +123,13 @@ func NewDescribeReader(t *testing.T, logger *slog.Logger, describeType types.Des
 }
 
 // NewCloseReader creates a buffer.Reader containing a Close message ready to be processed.
-// closeType should be 'S' for statement or 'P' for portal.
-func NewCloseReader(t *testing.T, logger *slog.Logger, closeType byte, name string) *buffer.Reader {
+func NewCloseReader(t *testing.T, logger *slog.Logger, closeType types.CloseMessage, name string) *buffer.Reader {
 	t.Helper()
 
 	inputBuf := &bytes.Buffer{}
 	writer := NewWriter(t, inputBuf)
 	writer.Start(types.ClientClose)
-	writer.AddByte(closeType)
+	writer.AddByte(byte(closeType))
 	writer.AddString(name)
 	writer.AddNullTerminate()
 	if err := writer.End(); err != nil {

--- a/pkg/types/types.go
+++ b/pkg/types/types.go
@@ -9,6 +9,9 @@ type ServerMessage byte
 // DescribeMessage represents a client describe message type.
 type DescribeMessage byte
 
+// CloseMessage represents a client close message type.
+type CloseMessage byte
+
 // http://www.postgresql.org/docs/9.4/static/protocol-message-formats.html
 const (
 	ClientBind        ClientMessage = 'B'
@@ -45,6 +48,9 @@ const (
 
 	DescribePortal    DescribeMessage = 'P'
 	DescribeStatement DescribeMessage = 'S'
+
+	ClosePortal    CloseMessage = 'P'
+	CloseStatement CloseMessage = 'S'
 )
 
 func (m ClientMessage) String() string {
@@ -126,6 +132,17 @@ func (m DescribeMessage) String() string {
 	case DescribePortal:
 		return "Portal"
 	case DescribeStatement:
+		return "Statement"
+	default:
+		return "Unknown"
+	}
+}
+
+func (m CloseMessage) String() string {
+	switch m {
+	case ClosePortal:
+		return "Portal"
+	case CloseStatement:
 		return "Statement"
 	default:
 		return "Unknown"


### PR DESCRIPTION
This cleans up statement and portal caches when receiving a Close message, and cleans up the portal cache when a statement in the cache gets overwritten.
