### PR TITLE
Add an error sanitizer hook

### DIFF
--- a/error.go
+++ b/error.go
@@ -29,6 +29,10 @@ const (
 // a trailing ReadyForQuery. Use this in contexts where no session is available
 // (e.g. authentication) or where you need to control ReadyForQuery yourself.
 func WriteUnterminatedError(writer *buffer.Writer, err error) error {
+	if writer.ErrorSanitizer != nil {
+		err = writer.ErrorSanitizer(err)
+	}
+
 	desc := psqlerr.Flatten(err)
 
 	writer.Start(types.ServerErrorResponse)
@@ -77,10 +81,6 @@ func WriteUnterminatedError(writer *buffer.Writer, err error) error {
 // ErrorResponse and sets `discardUntilSync` (ReadyForQuery comes from Sync).
 // In simple query mode it writes ErrorResponse + ReadyForQuery.
 func (srv *Session) WriteError(writer *buffer.Writer, err error) error {
-	if srv.ErrorSanitizer != nil {
-		err = srv.ErrorSanitizer(err)
-	}
-
 	if werr := WriteUnterminatedError(writer, err); werr != nil {
 		return werr
 	}

--- a/error.go
+++ b/error.go
@@ -77,6 +77,10 @@ func WriteUnterminatedError(writer *buffer.Writer, err error) error {
 // ErrorResponse and sets `discardUntilSync` (ReadyForQuery comes from Sync).
 // In simple query mode it writes ErrorResponse + ReadyForQuery.
 func (srv *Session) WriteError(writer *buffer.Writer, err error) error {
+	if srv.ErrorSanitizer != nil {
+		err = srv.ErrorSanitizer(err)
+	}
+
 	if werr := WriteUnterminatedError(writer, err); werr != nil {
 		return werr
 	}

--- a/options.go
+++ b/options.go
@@ -186,6 +186,17 @@ func ParallelPipeline(config ParallelPipelineConfig) OptionFn {
 	}
 }
 
+// ErrorSanitizer sets a function that transforms errors before they are sent
+// to the client. This hook is called in Session.ErrorCode before writing the
+// ErrorResponse to the wire. It can be used to mask internal error details,
+// generate error IDs, or rewrite error messages.
+func ErrorSanitizer(fn func(error) error) OptionFn {
+	return func(srv *Server) error {
+		srv.ErrorSanitizer = fn
+		return nil
+	}
+}
+
 // MessageBufferSize sets the message buffer size which is allocated once a new
 // connection gets constructed. If a negative value or zero value is provided is
 // the default message buffer size used.

--- a/options.go
+++ b/options.go
@@ -191,8 +191,8 @@ func ParallelPipeline(config ParallelPipelineConfig) OptionFn {
 // ErrorResponse to the wire. It can be used to mask internal error details,
 // generate error IDs, or rewrite error messages.
 // Note: this does not apply to errors written during authentication, as auth
-// strategies write errors directly. Sanitize errors in your AuthStrategy or
-// validation function if needed.
+// strategies happen before seeions are created. Sanitize errors in your
+// AuthStrategy or validation function if needed.
 func ErrorSanitizer(fn func(error) error) OptionFn {
 	return func(srv *Server) error {
 		srv.ErrorSanitizer = fn

--- a/options.go
+++ b/options.go
@@ -187,12 +187,9 @@ func ParallelPipeline(config ParallelPipelineConfig) OptionFn {
 }
 
 // ErrorSanitizer sets a function that transforms errors before they are sent
-// to the client. This hook is called in Session.WriteError before writing the
-// ErrorResponse to the wire. It can be used to mask internal error details,
-// generate error IDs, or rewrite error messages.
-// Note: this does not apply to errors written during authentication, as auth
-// strategies happen before seeions are created. Sanitize errors in your
-// AuthStrategy or validation function if needed.
+// to the client. This hook is called before writing any ErrorResponse to the
+// wire, including during authentication. It can be used to mask internal error
+// details, generate error IDs, or rewrite error messages.
 func ErrorSanitizer(fn func(error) error) OptionFn {
 	return func(srv *Server) error {
 		srv.ErrorSanitizer = fn

--- a/options.go
+++ b/options.go
@@ -187,9 +187,12 @@ func ParallelPipeline(config ParallelPipelineConfig) OptionFn {
 }
 
 // ErrorSanitizer sets a function that transforms errors before they are sent
-// to the client. This hook is called in Session.ErrorCode before writing the
+// to the client. This hook is called in Session.WriteError before writing the
 // ErrorResponse to the wire. It can be used to mask internal error details,
 // generate error IDs, or rewrite error messages.
+// Note: this does not apply to errors written during authentication, as auth
+// strategies write errors directly. Sanitize errors in your AuthStrategy or
+// validation function if needed.
 func ErrorSanitizer(fn func(error) error) OptionFn {
 	return func(srv *Server) error {
 		srv.ErrorSanitizer = fn

--- a/pkg/buffer/writer.go
+++ b/pkg/buffer/writer.go
@@ -12,10 +12,11 @@ import (
 // Writer provides a convenient way to write pgwire protocol messages
 type Writer struct {
 	io.Writer
-	logger *slog.Logger
-	frame  bytes.Buffer
-	putbuf [64]byte // buffer used to construct messages which could be written to the writer frame buffer
-	err    error
+	logger         *slog.Logger
+	frame          bytes.Buffer
+	putbuf         [64]byte // buffer used to construct messages which could be written to the writer frame buffer
+	err            error
+	ErrorSanitizer func(error) error
 }
 
 // NewWriter constructs a new Postgres buffered message writer for the given io.Writer

--- a/wire.go
+++ b/wire.go
@@ -128,6 +128,7 @@ type Server struct {
 	TerminateConn    CloseFn
 	FlushConn        FlushFn
 	ParallelPipeline ParallelPipelineConfig
+	ErrorSanitizer   func(error) error
 	Version          string
 	ShutdownTimeout  time.Duration
 	typeExtension    func(*pgtype.Map)

--- a/wire.go
+++ b/wire.go
@@ -234,6 +234,7 @@ func (srv *Server) serve(ctx context.Context, conn net.Conn) error {
 	srv.logger.Debug("handshake successful, validating authentication")
 
 	writer := buffer.NewWriter(srv.logger, conn)
+	writer.ErrorSanitizer = srv.ErrorSanitizer
 	ctx, err = srv.readClientParameters(ctx, reader)
 	if err != nil {
 		return err


### PR DESCRIPTION
It would be nice to be able to mask any unexpected errors before returning them to the client and do so consistently everywhere.
 
This introduces an `ErrorSanitizer` hook, which lets user define a unified way to sanitize error messages right before they are written. The hook gets called inside `WriteUnterminatedError`, which is how all errors get written, so this ensures `ErrorSanitizer` is always called. 
