### PR TITLE
Handle fatal errors correctly

### DIFF
--- a/auth.go
+++ b/auth.go
@@ -77,7 +77,7 @@ func ClearTextPassword(validate func(ctx context.Context, database, username, pa
 		}
 
 		if !valid {
-			authErr := pgerror.WithCode(errors.New("invalid username/password"), codes.InvalidPassword)
+			authErr := pgerror.WithSeverity(pgerror.WithCode(errors.New("invalid username/password"), codes.InvalidPassword), pgerror.LevelFatal)
 			err = WriteUnterminatedError(writer, authErr)
 			if err != nil {
 				return ctx, err

--- a/command.go
+++ b/command.go
@@ -27,7 +27,7 @@ func NewErrUnimplementedMessageType(t types.ClientMessage) error {
 // the given name.
 func NewErrUnkownStatement(name string) error {
 	err := fmt.Errorf("unknown executeable: %s", name)
-	return psqlerr.WithSeverity(psqlerr.WithCode(err, codes.InvalidPreparedStatementDefinition), psqlerr.LevelFatal)
+	return psqlerr.WithSeverity(psqlerr.WithCode(err, codes.InvalidPreparedStatementDefinition), psqlerr.LevelError)
 }
 
 // NewErrUndefinedStatement is returned whenever no statement has been defined

--- a/error.go
+++ b/error.go
@@ -1,7 +1,6 @@
 package wire
 
 import (
-	"github.com/jeroenrinzema/psql-wire/codes"
 	psqlerr "github.com/jeroenrinzema/psql-wire/errors"
 	"github.com/jeroenrinzema/psql-wire/pkg/buffer"
 	"github.com/jeroenrinzema/psql-wire/pkg/types"
@@ -81,17 +80,17 @@ func (srv *Session) WriteError(writer *buffer.Writer, err error) error {
 		return werr
 	}
 
-	if srv.inExtendedQuery {
-		srv.discardUntilSync = true
-		return nil
-	}
-
 	desc := psqlerr.Flatten(err)
 
-	// NOTE: we are writing a ready for query message to indicate the end of a
-	// command cycle. However, for authentication failures, we skip this
-	// because the connection will be terminated.
-	if desc.Code == codes.InvalidPassword {
+	// FATAL and PANIC errors terminate the connection. The client expects the
+	// server to close after sending the ErrorResponse, so we must not wait
+	// for a Sync or send ReadyForQuery.
+	if desc.Severity == psqlerr.LevelFatal || desc.Severity == psqlerr.LevelPanic {
+		return err
+	}
+
+	if srv.inExtendedQuery {
+		srv.discardUntilSync = true
 		return nil
 	}
 

--- a/error_test.go
+++ b/error_test.go
@@ -226,8 +226,36 @@ func TestSessionErrorCode(t *testing.T) {
 			Portals:    &DefaultPortalCache{},
 		}
 
-		err := session.WriteError(writer, psqlerr.WithCode(errors.New("invalid username/password"), codes.InvalidPassword))
+		inputErr := psqlerr.WithSeverity(psqlerr.WithCode(errors.New("invalid username/password"), codes.InvalidPassword), psqlerr.LevelFatal)
+		err := session.WriteError(writer, inputErr)
+		assert.ErrorIs(t, err, inputErr)
+
+		reader := buffer.NewReader(logger, sink, buffer.DefaultBufferSize)
+
+		msgType, _, err := reader.ReadTypedMsg()
 		assert.NoError(t, err)
+		assert.Equal(t, types.ServerMessage(msgType), types.ServerErrorResponse)
+
+		_, _, err = reader.ReadTypedMsg()
+		assert.Error(t, err)
+	})
+
+	t.Run("fatal error in extended query returns error instead of waiting for sync", func(t *testing.T) {
+		logger := slogt.New(t)
+		sink := bytes.NewBuffer([]byte{})
+		writer := buffer.NewWriter(logger, sink)
+
+		session := &Session{
+			Server:          &Server{logger: logger},
+			Statements:      &DefaultStatementCache{},
+			Portals:         &DefaultPortalCache{},
+			inExtendedQuery: true,
+		}
+
+		inputErr := psqlerr.WithSeverity(psqlerr.WithCode(errors.New("fatal failure"), codes.FeatureNotSupported), psqlerr.LevelFatal)
+		err := session.WriteError(writer, inputErr)
+		assert.ErrorIs(t, err, inputErr)
+		assert.False(t, session.discardUntilSync)
 
 		reader := buffer.NewReader(logger, sink, buffer.DefaultBufferSize)
 


### PR DESCRIPTION
There was special behaviour for the `InvalidPassword` error type, but there are many more possibilities for fatal errors. Query handlers might return them for a variety of reasons. All of such errors are expected to close the connection, that's what FATAL (or PANIC) means. This starts handling such non-recoverable errors correctly, by closing the connection when they occur.

It also marks `NewErrUnkownStatement` as ERROR, instead of FATAL, because it is not a fatal error (and now it creates different behaviour).
