### PR TITLE
Report error when an unknown portal is executed

### DIFF
--- a/cache.go
+++ b/cache.go
@@ -7,6 +7,8 @@ import (
 	"iter"
 	"sync"
 
+	"github.com/jeroenrinzema/psql-wire/codes"
+	psqlerr "github.com/jeroenrinzema/psql-wire/errors"
 	"github.com/jeroenrinzema/psql-wire/pkg/buffer"
 	"github.com/jeroenrinzema/psql-wire/pkg/types"
 )
@@ -230,8 +232,8 @@ func (cache *DefaultPortalCache) Bind(ctx context.Context, name string, stmt *St
 }
 
 func (cache *DefaultPortalCache) Get(ctx context.Context, name string) (*Portal, error) {
-	cache.mu.Lock()
-	defer cache.mu.Unlock()
+	cache.mu.RLock()
+	defer cache.mu.RUnlock()
 
 	if cache.portals == nil {
 		return nil, nil
@@ -253,22 +255,22 @@ func (cache *DefaultPortalCache) Execute(ctx context.Context, name string, limit
 		}
 	}()
 
-	// Look up the portal under the lock, then release before executing.
-	// The handler may call back into the cache so we must make sure we don't
-	// hold the lock for the execute duration. e.g. a handler for DEALLOCATE
-	// may call back into the cache to delete a portal.
-	cache.mu.RLock()
-	if cache.portals == nil {
-		cache.mu.RUnlock()
-		return nil
+	portal, err := cache.Get(ctx, name)
+	if err != nil {
+		return err
+	}
+	if portal == nil {
+		// Match real PostgreSQL: Execute on a non-existent portal is an
+		// error, not a silent no-op.
+		return psqlerr.WithCode(fmt.Errorf("portal %q does not exist", name), codes.InvalidCursorName)
 	}
 
-	portal, has := cache.portals[name]
-	cache.mu.RUnlock()
-	if !has {
-		return nil
-	}
-
+	// When accessesing and changing the fields of the cache cache we hold the
+	// required locks. But we make sure not to hold them during the execute
+	// call itself. This is needed because the handler may call back into the
+	// cache so we must make sure we don't hold the lock for the execute
+	// duration. e.g. a handler for DEALLOCATE may call back into the cache to
+	// delete a portal.
 	cache.mu.Lock()
 	cache.executing = portal
 	cache.mu.Unlock()

--- a/cache_test.go
+++ b/cache_test.go
@@ -6,6 +6,8 @@ import (
 	"log/slog"
 	"testing"
 
+	"github.com/jeroenrinzema/psql-wire/codes"
+	psqlerr "github.com/jeroenrinzema/psql-wire/errors"
 	"github.com/jeroenrinzema/psql-wire/pkg/buffer"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -63,4 +65,39 @@ func TestDeleteByStatementFromHandler(t *testing.T) {
 	portal, err := cache.Get(ctx, "portal")
 	require.NoError(t, err)
 	assert.Nil(t, portal)
+}
+
+// TestExecuteUnknownPortalReturnsError verifies that Execute on a portal that
+// was never bound (or has already been closed) returns an error tagged with
+// the InvalidCursorName code, matching real PostgreSQL behavior. Previously
+// this was a silent no-op, which made it impossible for clients to detect
+// that their portal had been invalidated.
+func TestExecuteUnknownPortalReturnsError(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+
+	t.Run("never bound", func(t *testing.T) {
+		t.Parallel()
+		cache := &DefaultPortalCache{}
+		err := cache.Execute(ctx, "missing", NoLimit, nil, newDiscardWriter())
+		require.Error(t, err)
+		assert.Equal(t, codes.InvalidCursorName, psqlerr.GetCode(err))
+		assert.Contains(t, err.Error(), `"missing"`)
+	})
+
+	t.Run("after close", func(t *testing.T) {
+		t.Parallel()
+		cache := &DefaultPortalCache{}
+		stmt := &Statement{
+			fn: func(ctx context.Context, writer DataWriter, _ []Parameter) error {
+				return writer.Complete("OK")
+			},
+		}
+		require.NoError(t, cache.Bind(ctx, "p", stmt, nil, nil))
+		require.NoError(t, cache.Delete(ctx, "p"))
+
+		err := cache.Execute(ctx, "p", NoLimit, nil, newDiscardWriter())
+		require.Error(t, err)
+		assert.Equal(t, codes.InvalidCursorName, psqlerr.GetCode(err))
+	})
 }


### PR DESCRIPTION
Well behaving clients should only try to execute portals that have actually been created. Not all clients are well-behaving though. This makes it a clear error when the client tries to execute a portal that does not exist, as opposed to silently returning an empty result set.
