### PR TITLE
Pass all query information to ParseFn

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,9 +28,9 @@ func main() {
 	wire.ListenAndServe("127.0.0.1:5432", handler)
 }
 
-func handler(ctx context.Context, query string) (wire.PreparedStatements, error) {
+func handler(ctx context.Context, query wire.Query) (wire.PreparedStatements, error) {
 	return wire.Prepared(wire.NewStatement(func(ctx context.Context, writer wire.DataWriter, parameters []wire.Parameter) error {
-		fmt.Println(query)
+		fmt.Println(query.Query)
 		return writer.Complete("OK")
 	})), nil
 }

--- a/cancel_test.go
+++ b/cancel_test.go
@@ -81,7 +81,7 @@ func (ts *testServer) cancelRequest(ctx context.Context, processID, secretKey in
 	return nil
 }
 
-func (ts *testServer) handler(ctx context.Context, query string) (PreparedStatements, error) {
+func (ts *testServer) handler(ctx context.Context, query Query) (PreparedStatements, error) {
 	handle := func(ctx context.Context, writer DataWriter, parameters []Parameter) error {
 		queryCtx, cancel := context.WithCancel(ctx)
 		defer cancel()

--- a/command.go
+++ b/command.go
@@ -315,7 +315,7 @@ func (srv *Session) handleSimpleQuery(ctx context.Context, reader *buffer.Reader
 		return readyForQuery(writer, types.ServerIdle)
 	}
 
-	statements, err := srv.parse(ctx, query)
+	statements, err := srv.parse(ctx, Query{Query: query, SimpleQuery: true})
 	if err != nil {
 		return srv.WriteError(writer, err)
 	}
@@ -376,12 +376,15 @@ func (srv *Session) handleParse(ctx context.Context, reader *buffer.Reader, writ
 
 	srv.logger.Debug("predefined parameters", slog.Int("parameters", int(parameters)))
 
+	parameterOIDs := make([]uint32, parameters)
 	for i := uint16(0); i < parameters; i++ {
-		// TODO: Specifies the object ID of the parameter data type
-		//
 		// Specifies the object ID of the parameter data type. Placing a zero here
 		// is equivalent to leaving the type unspecified.
-		// `reader.GetUint32()`
+		oid, err := reader.GetUint32()
+		if err != nil {
+			return err
+		}
+		parameterOIDs[i] = oid
 	}
 
 	existing, err := srv.Statements.Get(ctx, name)
@@ -397,10 +400,10 @@ func (srv *Session) handleParse(ctx context.Context, reader *buffer.Reader, writ
 	}
 
 	if srv.ParallelPipeline.Enabled {
-		return srv.parsePipelined(ctx, writer, name, query)
+		return srv.parsePipelined(ctx, writer, name, query, parameterOIDs)
 	}
 
-	statement, err := singleStatement(srv.parse(ctx, query))
+	statement, err := singleStatement(srv.parse(ctx, Query{Query: query, ParameterOIDs: parameterOIDs}))
 	if err != nil {
 		return srv.WriteError(writer, err)
 	}
@@ -417,8 +420,8 @@ func (srv *Session) handleParse(ctx context.Context, reader *buffer.Reader, writ
 }
 
 // parsePipelined handles Parse in parallel pipeline mode
-func (srv *Session) parsePipelined(ctx context.Context, writer *buffer.Writer, name, query string) error {
-	statement, err := singleStatement(srv.parse(ctx, query))
+func (srv *Session) parsePipelined(ctx context.Context, writer *buffer.Writer, name, query string, parameterOIDs []uint32) error {
+	statement, err := singleStatement(srv.parse(ctx, Query{Query: query, ParameterOIDs: parameterOIDs}))
 	if err != nil {
 		return srv.drainQueueAndWriteError(ctx, writer, err)
 	}

--- a/command_execute_test.go
+++ b/command_execute_test.go
@@ -25,7 +25,7 @@ func TestHandleExecute_ParallelPipeline_Success(t *testing.T) {
 
 	logger := slogt.New(t)
 
-	mockParse := func(ctx context.Context, query string) (PreparedStatements, error) {
+	mockParse := func(ctx context.Context, query Query) (PreparedStatements, error) {
 		stmt := NewStatement(
 			func(ctx context.Context, writer DataWriter, parameters []Parameter) error {
 				if err := writer.Row([]any{"Hello World"}); err != nil {

--- a/command_parse_test.go
+++ b/command_parse_test.go
@@ -21,7 +21,7 @@ func TestHandleParse_ParallelPipeline_Success(t *testing.T) {
 
 	ctx := context.Background()
 
-	mockParse := func(ctx context.Context, query string) (PreparedStatements, error) {
+	mockParse := func(ctx context.Context, query Query) (PreparedStatements, error) {
 		stmt := NewStatement(
 			func(ctx context.Context, writer DataWriter, parameters []Parameter) error { return nil },
 			WithParameters([]uint32{pgtype.TextOID, pgtype.Int4OID}),
@@ -66,7 +66,7 @@ func TestHandleParse_ParallelPipeline_MultipleCommands(t *testing.T) {
 
 	ctx := context.Background()
 	logger := slogt.New(t)
-	mockParse := func(ctx context.Context, query string) (PreparedStatements, error) {
+	mockParse := func(ctx context.Context, query Query) (PreparedStatements, error) {
 		stmt := NewStatement(func(ctx context.Context, writer DataWriter, parameters []Parameter) error { return nil })
 		return PreparedStatements{stmt}, nil
 	}
@@ -108,8 +108,8 @@ func TestHandleParse_ParallelPipeline_Error(t *testing.T) {
 	ctx := context.Background()
 	logger := slogt.New(t)
 
-	mockParse := func(ctx context.Context, query string) (PreparedStatements, error) {
-		if query == "INVALID SQL" {
+	mockParse := func(ctx context.Context, query Query) (PreparedStatements, error) {
+		if query.Query == "INVALID SQL" {
 			return nil, errors.New("syntax error at or near 'INVALID'")
 		}
 		return PreparedStatements{NewStatement(func(ctx context.Context, w DataWriter, p []Parameter) error { return nil })}, nil
@@ -157,7 +157,7 @@ func TestHandleParse_OverwriteRemovesRelatedPortals(t *testing.T) {
 	ctx = setTypeInfo(ctx, typeMap)
 	logger := slogt.New(t)
 
-	mockParse := func(ctx context.Context, query string) (PreparedStatements, error) {
+	mockParse := func(ctx context.Context, query Query) (PreparedStatements, error) {
 		return PreparedStatements{NewStatement(
 			func(ctx context.Context, writer DataWriter, parameters []Parameter) error {
 				return writer.Complete("SELECT 1")

--- a/command_test.go
+++ b/command_test.go
@@ -2,8 +2,10 @@ package wire
 
 import (
 	"context"
+	"encoding/binary"
 	"fmt"
 	"net"
+	"sync"
 	"testing"
 
 	"github.com/jackc/pgx/v5"
@@ -60,7 +62,7 @@ func TestBindMessageParameters(t *testing.T) {
 		},
 	}
 
-	handler := func(ctx context.Context, query string) (PreparedStatements, error) {
+	handler := func(ctx context.Context, query Query) (PreparedStatements, error) {
 		handle := func(ctx context.Context, writer DataWriter, parameters []Parameter) error {
 			t.Log("serving query")
 
@@ -75,7 +77,7 @@ func TestBindMessageParameters(t *testing.T) {
 			return writer.Complete("SELECT 1")
 		}
 
-		return Prepared(NewStatement(handle, WithColumns(columns), WithParameters(ParseParameters(query)))), nil
+		return Prepared(NewStatement(handle, WithColumns(columns), WithParameters(ParseParameters(query.Query)))), nil
 	}
 
 	server, err := NewServer(handler, Logger(slogt.New(t)))
@@ -183,7 +185,7 @@ func TestPortalSuspended(t *testing.T) {
 		},
 	}
 
-	handler := func(ctx context.Context, query string) (PreparedStatements, error) {
+	handler := func(ctx context.Context, query Query) (PreparedStatements, error) {
 		handle := func(ctx context.Context, writer DataWriter, parameters []Parameter) error {
 			for i := 0; i < totalRows; i++ {
 				if err := writer.Row([]any{int32(i)}); err != nil {
@@ -251,7 +253,7 @@ func TestReExecuteCompletedPortal(t *testing.T) {
 		},
 	}
 
-	handler := func(ctx context.Context, query string) (PreparedStatements, error) {
+	handler := func(ctx context.Context, query Query) (PreparedStatements, error) {
 		handle := func(ctx context.Context, writer DataWriter, parameters []Parameter) error {
 			if err := writer.Row([]any{int32(1)}); err != nil {
 				return err
@@ -296,4 +298,134 @@ func TestReExecuteCompletedPortal(t *testing.T) {
 	client.ExpectMsg(t, types.ServerReady)
 
 	client.Close(t)
+}
+
+// TestClientParameterTypeMismatch demonstrates that when a client sends binary
+// parameters using a smaller integer type (e.g. int2) than what the server
+// would otherwise declare (e.g. int8), the ParseFn can use the parameterOIDs
+// argument to match the client's types and decode correctly.
+//
+// This happens in practice with clients like psycopg3 that encode small Python
+// ints as int2 (2 bytes binary), while the server-side resolved type may be
+// int8 (bigint). PostgreSQL handles this via implicit casts at the planning
+// level. psql-wire passes the client-specified parameter OIDs from the Parse
+// message to ParseFn so handlers can do the same.
+func TestClientParameterTypeMismatch(t *testing.T) {
+	t.Parallel()
+
+	columns := Columns{
+		{
+			Table: 0,
+			Name:  "val",
+			Oid:   pgtype.Int8OID,
+			Width: 8,
+		},
+	}
+
+	handler := func(ctx context.Context, query Query) (PreparedStatements, error) {
+		// The ParameterOIDs slice tells us what types the client will
+		// send binary data as. We can use this to set WithParameters to
+		// match the client's types, so Scan decodes correctly.
+		parameterOIDs := query.ParameterOIDs
+		if len(parameterOIDs) == 0 {
+			parameterOIDs = ParseParameters(query.Query)
+		}
+
+		handle := func(ctx context.Context, writer DataWriter, parameters []Parameter) error {
+			val, err := parameters[0].Scan(parameterOIDs[0])
+			if err != nil {
+				return err
+			}
+
+			writer.Row([]any{val}) //nolint:errcheck
+			return writer.Complete("SELECT 1")
+		}
+
+		return Prepared(NewStatement(handle,
+			WithColumns(columns),
+			WithParameters(parameterOIDs),
+		)), nil
+	}
+
+	server, err := NewServer(handler, Logger(slogt.New(t)))
+	require.NoError(t, err)
+
+	address := TListenAndServe(t, server)
+
+	ctx := context.Background()
+	connstr := fmt.Sprintf("postgres://%s:%d", address.IP, address.Port)
+
+	conn, err := pgx.Connect(ctx, connstr)
+	require.NoError(t, err)
+	defer conn.Close(ctx) //nolint:errcheck
+
+	t.Run("int2 binary for int8 parameter", func(t *testing.T) {
+		int2Bytes := make([]byte, 2)
+		binary.BigEndian.PutUint16(int2Bytes, 42)
+
+		result := conn.PgConn().ExecParams(ctx,
+			"SELECT $1",
+			[][]byte{int2Bytes},
+			[]uint32{pgtype.Int2OID},
+			[]int16{pgx.BinaryFormatCode},
+			nil,
+		)
+		_, err := result.Close()
+		assert.NoError(t, err, "handler should decode binary int2 via ClientOID()")
+	})
+}
+
+// TestParseFnSimpleQueryFlag verifies that the Query.SimpleQuery flag reflects
+// which protocol a query arrived on: true for the simple query protocol and
+// false for the extended query (Parse/Bind/Execute) protocol.
+func TestParseFnSimpleQueryFlag(t *testing.T) {
+	t.Parallel()
+
+	var mu sync.Mutex
+	captured := map[string]Query{}
+
+	handler := func(ctx context.Context, query Query) (PreparedStatements, error) {
+		mu.Lock()
+		captured[query.Query] = query
+		mu.Unlock()
+
+		handle := func(ctx context.Context, writer DataWriter, parameters []Parameter) error {
+			return writer.Complete("SELECT 0")
+		}
+		return Prepared(NewStatement(handle)), nil
+	}
+
+	server, err := NewServer(handler, Logger(slogt.New(t)))
+	require.NoError(t, err)
+
+	address := TListenAndServe(t, server)
+
+	ctx := context.Background()
+	connstr := fmt.Sprintf("postgres://%s:%d", address.IP, address.Port)
+
+	conn, err := pgx.Connect(ctx, connstr)
+	require.NoError(t, err)
+	defer conn.Close(ctx) //nolint:errcheck
+
+	// The simple query protocol carries the query in a single Query message.
+	_, err = conn.Exec(ctx, "SELECT 'simple'", pgx.QueryExecModeSimpleProtocol)
+	require.NoError(t, err)
+
+	// ExecParams always uses the extended query protocol, sending a Parse
+	// message before Bind and Execute.
+	result := conn.PgConn().ExecParams(ctx, "SELECT 'extended'", nil, nil, nil, nil)
+	_, err = result.Close()
+	require.NoError(t, err)
+
+	mu.Lock()
+	defer mu.Unlock()
+
+	simple, ok := captured["SELECT 'simple'"]
+	require.True(t, ok, "simple query should have reached the handler")
+	assert.True(t, simple.SimpleQuery, "query received over the simple protocol should have SimpleQuery=true")
+	assert.Nil(t, simple.ParameterOIDs, "simple queries cannot specify parameter OIDs")
+
+	extended, ok := captured["SELECT 'extended'"]
+	require.True(t, ok, "extended query should have reached the handler")
+	assert.False(t, extended.SimpleQuery, "query received over the extended protocol should have SimpleQuery=false")
 }

--- a/copy_test.go
+++ b/copy_test.go
@@ -43,8 +43,8 @@ func TestCopyReaderText(t *testing.T) {
 		},
 	}
 
-	handler := func(ctx context.Context, query string) (PreparedStatements, error) {
-		log.Println("incoming SQL query:", query)
+	handler := func(ctx context.Context, query Query) (PreparedStatements, error) {
+		log.Println("incoming SQL query:", query.Query)
 
 		handle := func(ctx context.Context, writer DataWriter, parameters []Parameter) error {
 			log.Println("copying data")
@@ -153,8 +153,8 @@ func TestCopyReaderTextNullAndEscape(t *testing.T) {
 		},
 	}
 
-	handler := func(ctx context.Context, query string) (PreparedStatements, error) {
-		log.Println("incoming SQL query:", query)
+	handler := func(ctx context.Context, query Query) (PreparedStatements, error) {
+		log.Println("incoming SQL query:", query.Query)
 
 		handle := func(ctx context.Context, writer DataWriter, parameters []Parameter) error {
 			log.Println("copying data")

--- a/error_test.go
+++ b/error_test.go
@@ -21,7 +21,7 @@ import (
 )
 
 func TestErrorCode(t *testing.T) {
-	handler := func(ctx context.Context, query string) (PreparedStatements, error) {
+	handler := func(ctx context.Context, query Query) (PreparedStatements, error) {
 		stmt := NewStatement(func(ctx context.Context, writer DataWriter, parameters []Parameter) error {
 			return psqlerr.WithSeverity(psqlerr.WithCode(errors.New("unimplemented feature"), codes.FeatureNotSupported), psqlerr.LevelFatal)
 		})
@@ -70,8 +70,8 @@ func TestErrorCode(t *testing.T) {
 func TestExtendedQueryParseErrorRecovery(t *testing.T) {
 	t.Parallel()
 
-	handler := func(ctx context.Context, query string) (PreparedStatements, error) {
-		if query == "SELECT error" {
+	handler := func(ctx context.Context, query Query) (PreparedStatements, error) {
+		if query.Query == "SELECT error" {
 			return nil, psqlerr.WithCode(errors.New("test error"), codes.Syntax)
 		}
 
@@ -119,10 +119,10 @@ func TestExtendedQueryParseErrorRecovery(t *testing.T) {
 func TestExtendedQueryExecuteErrorRecovery(t *testing.T) {
 	t.Parallel()
 
-	handler := func(ctx context.Context, query string) (PreparedStatements, error) {
+	handler := func(ctx context.Context, query Query) (PreparedStatements, error) {
 		columns := Columns{{Name: "result", Oid: 25}} // text
 
-		if query == "SELECT error" {
+		if query.Query == "SELECT error" {
 			stmt := NewStatement(func(ctx context.Context, writer DataWriter, parameters []Parameter) error {
 				return psqlerr.WithCode(errors.New("execution failed"), codes.DataException)
 			}, WithColumns(columns))
@@ -276,7 +276,7 @@ func TestDiscardUntilSync(t *testing.T) {
 	ctx = setTypeInfo(ctx, typeMap)
 	logger := slogt.New(t)
 
-	mockParse := func(ctx context.Context, query string) (PreparedStatements, error) {
+	mockParse := func(ctx context.Context, query Query) (PreparedStatements, error) {
 		stmt := NewStatement(
 			func(ctx context.Context, writer DataWriter, parameters []Parameter) error {
 				return errors.New("query failed")
@@ -367,7 +367,7 @@ func TestRowReturnsEncodeError(t *testing.T) {
 
 	var rowErr error
 
-	handler := func(ctx context.Context, query string) (PreparedStatements, error) {
+	handler := func(ctx context.Context, query Query) (PreparedStatements, error) {
 		columns := Columns{{Name: "val", Oid: pgtype.Int4OID}}
 
 		stmt := NewStatement(func(ctx context.Context, writer DataWriter, parameters []Parameter) error {

--- a/examples/auth/main.go
+++ b/examples/auth/main.go
@@ -105,8 +105,8 @@ var table = wire.Columns{
 }
 
 // wireHandler processes incoming SQL queries
-func (s *PostgreServer) wireHandler(ctx context.Context, query string) (wire.PreparedStatements, error) {
-	s.logger.Printf("incoming SQL query: %s", query)
+func (s *PostgreServer) wireHandler(ctx context.Context, query wire.Query) (wire.PreparedStatements, error) {
+	s.logger.Printf("incoming SQL query: %s", query.Query)
 
 	handle := func(ctx context.Context, writer wire.DataWriter, parameters []wire.Parameter) error {
 		writer.Row([]any{"John", true, 29})   //nolint:errcheck

--- a/examples/copy/main.go
+++ b/examples/copy/main.go
@@ -36,8 +36,8 @@ var table = wire.Columns{
 	},
 }
 
-func handler(ctx context.Context, query string) (wire.PreparedStatements, error) {
-	log.Println("incoming SQL query:", query)
+func handler(ctx context.Context, query wire.Query) (wire.PreparedStatements, error) {
+	log.Println("incoming SQL query:", query.Query)
 
 	handle := func(ctx context.Context, writer wire.DataWriter, parameters []wire.Parameter) error {
 		log.Println("copying data")

--- a/examples/error/main.go
+++ b/examples/error/main.go
@@ -15,8 +15,8 @@ func main() {
 	wire.ListenAndServe("127.0.0.1:5432", handler) //nolint:errcheck
 }
 
-func handler(ctx context.Context, query string) (wire.PreparedStatements, error) {
-	log.Println("incoming SQL query:", query)
+func handler(ctx context.Context, query wire.Query) (wire.PreparedStatements, error) {
+	log.Println("incoming SQL query:", query.Query)
 
 	err := errors.New("unimplemented feature")
 	err = psqlerr.WithCode(err, codes.FeatureNotSupported)

--- a/examples/pipelining/main.go
+++ b/examples/pipelining/main.go
@@ -40,8 +40,8 @@ var table = wire.Columns{
 	},
 }
 
-func handler(ctx context.Context, query string) (wire.PreparedStatements, error) {
-	log.Println("incoming SQL query:", query)
+func handler(ctx context.Context, query wire.Query) (wire.PreparedStatements, error) {
+	log.Println("incoming SQL query:", query.Query)
 
 	handle := func(ctx context.Context, writer wire.DataWriter, parameters []wire.Parameter) error {
 		// Simulate work (database lookup, network call, etc.)

--- a/examples/session/main.go
+++ b/examples/session/main.go
@@ -32,8 +32,8 @@ func session(ctx context.Context) (context.Context, error) {
 	return context.WithValue(ctx, id, counter), nil
 }
 
-func handler(ctx context.Context, query string) (wire.PreparedStatements, error) {
-	log.Println("incoming SQL query:", query)
+func handler(ctx context.Context, query wire.Query) (wire.PreparedStatements, error) {
+	log.Println("incoming SQL query:", query.Query)
 
 	handle := func(ctx context.Context, writer wire.DataWriter, parameters []wire.Parameter) error {
 		session := ctx.Value(id).(int)

--- a/examples/simple/main.go
+++ b/examples/simple/main.go
@@ -34,8 +34,8 @@ var table = wire.Columns{
 	},
 }
 
-func handler(ctx context.Context, query string) (wire.PreparedStatements, error) {
-	log.Println("incoming SQL query:", query)
+func handler(ctx context.Context, query wire.Query) (wire.PreparedStatements, error) {
+	log.Println("incoming SQL query:", query.Query)
 
 	handle := func(ctx context.Context, writer wire.DataWriter, parameters []wire.Parameter) error {
 		writer.Row([]any{"John", true, 29})   //nolint:errcheck

--- a/examples/tls/main.go
+++ b/examples/tls/main.go
@@ -33,8 +33,8 @@ func run() error {
 	return server.ListenAndServe("127.0.0.1:5432")
 }
 
-func handler(ctx context.Context, query string) (wire.PreparedStatements, error) {
-	slog.Info("incoming SQL query", slog.String("query", query))
+func handler(ctx context.Context, query wire.Query) (wire.PreparedStatements, error) {
+	slog.Info("incoming SQL query", slog.String("query", query.Query))
 
 	handle := func(ctx context.Context, writer wire.DataWriter, parameters []wire.Parameter) error {
 		return writer.Complete("OK")

--- a/options.go
+++ b/options.go
@@ -12,9 +12,30 @@ import (
 	"github.com/jeroenrinzema/psql-wire/pkg/buffer"
 )
 
+// Query represents an incoming query which should be parsed into one or more
+// prepared statements. Besides the raw query string it carries metadata about
+// how the query was received by the server.
+type Query struct {
+	// Query holds the raw SQL query string as received from the client.
+	Query string
+
+	// ParameterOIDs holds the parameter type OIDs that the client specified in
+	// the Parse message. A zero OID means the client left that parameter's type
+	// unspecified. The amount of provided parameter OIDs may be less than the
+	// number of parameters that appear in the query string, indicating that the
+	// server can decide the types for the unspecified parameters. This slice is
+	// always empty for simple queries since the simple query protocol does not
+	// allow the client to specify parameter types.
+	ParameterOIDs []uint32
+
+	// SimpleQuery is true when the query was received through the simple query
+	// protocol instead of the extended query (Parse/Bind/Execute) protocol.
+	SimpleQuery bool
+}
+
 // ParseFn parses the given query and returns a prepared statement which could
 // be used to execute at a later point in time.
-type ParseFn func(ctx context.Context, query string) (PreparedStatements, error)
+type ParseFn func(ctx context.Context, query Query) (PreparedStatements, error)
 
 // PreparedStatementFn represents a query of which a statement has been
 // prepared. The statement could be executed at any point in time with the given

--- a/wire_test.go
+++ b/wire_test.go
@@ -47,7 +47,7 @@ func TListenAndServe(t *testing.T, server *Server) *net.TCPAddr {
 func TestClientConnect(t *testing.T) {
 	t.Parallel()
 
-	handler := func(ctx context.Context, query string) (PreparedStatements, error) {
+	handler := func(ctx context.Context, query Query) (PreparedStatements, error) {
 		statement := NewStatement(func(ctx context.Context, writer DataWriter, parameters []Parameter) error {
 			t.Log("serving query")
 			return writer.Complete("OK")
@@ -117,7 +117,7 @@ func TestClientConnect(t *testing.T) {
 func TestClientParameters(t *testing.T) {
 	t.Parallel()
 
-	handler := func(ctx context.Context, query string) (PreparedStatements, error) {
+	handler := func(ctx context.Context, query Query) (PreparedStatements, error) {
 		handle := func(ctx context.Context, writer DataWriter, parameters []Parameter) error {
 			writer.Row([]any{"John Doe"}) //nolint:errcheck
 			return writer.Complete("SELECT 1")
@@ -132,7 +132,7 @@ func TestClientParameters(t *testing.T) {
 			},
 		}
 
-		return Prepared(NewStatement(handle, WithColumns(columns), WithParameters(ParseParameters(query)))), nil
+		return Prepared(NewStatement(handle, WithColumns(columns), WithParameters(ParseParameters(query.Query)))), nil
 	}
 
 	server, err := NewServer(handler, Logger(slogt.New(t)))
@@ -190,7 +190,7 @@ func TestClientParameters(t *testing.T) {
 func TestServerWritingResult(t *testing.T) {
 	t.Parallel()
 
-	handler := func(ctx context.Context, query string) (PreparedStatements, error) {
+	handler := func(ctx context.Context, query Query) (PreparedStatements, error) {
 		handle := func(ctx context.Context, writer DataWriter, parameters []Parameter) error {
 			t.Log("serving query")
 			writer.Row([]any{"John", true, 28})   //nolint:errcheck
@@ -342,7 +342,7 @@ func TestServerHandlingMultipleConnections(t *testing.T) {
 
 func TOpenMockServer(t *testing.T) *net.TCPAddr {
 	t.Helper()
-	handler := func(ctx context.Context, query string) (PreparedStatements, error) {
+	handler := func(ctx context.Context, query Query) (PreparedStatements, error) {
 		handle := func(ctx context.Context, writer DataWriter, parameters []Parameter) error {
 			t.Log("serving query")
 			writer.Row([]any{20}) //nolint:errcheck
@@ -358,7 +358,7 @@ func TOpenMockServer(t *testing.T) *net.TCPAddr {
 			},
 		}
 
-		return Prepared(NewStatement(handle, WithColumns(columns), WithParameters(ParseParameters(query)))), nil
+		return Prepared(NewStatement(handle, WithColumns(columns), WithParameters(ParseParameters(query.Query)))), nil
 	}
 
 	server, err := NewServer(handler, Logger(slogt.New(t)))
@@ -376,7 +376,7 @@ func TestServerNULLValues(t *testing.T) {
 		nil,
 	}
 
-	handler := func(ctx context.Context, query string) (PreparedStatements, error) {
+	handler := func(ctx context.Context, query Query) (PreparedStatements, error) {
 		handle := func(ctx context.Context, writer DataWriter, parameters []Parameter) error {
 			t.Log("serving query")
 			writer.Row([]any{"John"}) //nolint:errcheck
@@ -505,7 +505,7 @@ func TestSessionAttributes(t *testing.T) {
 	t.Parallel()
 
 	var sessionAttributes map[string]interface{}
-	handler := func(ctx context.Context, query string) (PreparedStatements, error) {
+	handler := func(ctx context.Context, query Query) (PreparedStatements, error) {
 		SetAttribute(ctx, "test_key", "test_value")
 		SetAttribute(ctx, "numeric_key", 42)
 
@@ -567,8 +567,8 @@ func TestSessionAttributes(t *testing.T) {
 func TestServerCopyIn(t *testing.T) {
 	t.Parallel()
 
-	handler := func(ctx context.Context, query string) (PreparedStatements, error) {
-		t.Log("preparing query", query)
+	handler := func(ctx context.Context, query Query) (PreparedStatements, error) {
+		t.Log("preparing query", query.Query)
 
 		handle := func(ctx context.Context, writer DataWriter, parameters []Parameter) error {
 			t.Log("copying data")
@@ -701,7 +701,7 @@ func TestServerCopyIn(t *testing.T) {
 func TestServerShutdownWithContextDeadline(t *testing.T) {
 	t.Parallel()
 
-	handler := func(ctx context.Context, query string) (PreparedStatements, error) {
+	handler := func(ctx context.Context, query Query) (PreparedStatements, error) {
 		statement := NewStatement(func(ctx context.Context, writer DataWriter, parameters []Parameter) error {
 			return writer.Complete("OK")
 		})
@@ -732,7 +732,7 @@ func TestServerShutdownWithContextDeadline(t *testing.T) {
 func TestServerShutdownWithServerTimeout(t *testing.T) {
 	t.Parallel()
 
-	handler := func(ctx context.Context, query string) (PreparedStatements, error) {
+	handler := func(ctx context.Context, query Query) (PreparedStatements, error) {
 		statement := NewStatement(func(ctx context.Context, writer DataWriter, parameters []Parameter) error {
 			return writer.Complete("OK")
 		})
@@ -760,7 +760,7 @@ func TestServerShutdownWithServerTimeout(t *testing.T) {
 func TestServerShutdownUsesShortestTimeout(t *testing.T) {
 	t.Parallel()
 
-	handler := func(ctx context.Context, query string) (PreparedStatements, error) {
+	handler := func(ctx context.Context, query Query) (PreparedStatements, error) {
 		statement := NewStatement(func(ctx context.Context, writer DataWriter, parameters []Parameter) error {
 			return writer.Complete("OK")
 		})
@@ -797,7 +797,7 @@ func TestServerShutdownShorterTimeoutWins(t *testing.T) {
 	queryStarted.Add(1)
 	queryCanFinish.Add(1)
 
-	handler := func(ctx context.Context, query string) (PreparedStatements, error) {
+	handler := func(ctx context.Context, query Query) (PreparedStatements, error) {
 		statement := NewStatement(func(ctx context.Context, writer DataWriter, parameters []Parameter) error {
 			queryStarted.Done()
 			queryCanFinish.Wait() // Block until test releases it
@@ -855,7 +855,7 @@ func TestServerShutdownServerTimeoutWins(t *testing.T) {
 	queryStarted.Add(1)
 	queryCanFinish.Add(1)
 
-	handler := func(ctx context.Context, query string) (PreparedStatements, error) {
+	handler := func(ctx context.Context, query Query) (PreparedStatements, error) {
 		statement := NewStatement(func(ctx context.Context, writer DataWriter, parameters []Parameter) error {
 			queryStarted.Done()
 			queryCanFinish.Wait() // Block until test releases it
@@ -913,7 +913,7 @@ func TestServerShutdownTimeout(t *testing.T) {
 	queryStarted.Add(1)
 	queryCanFinish.Add(1)
 
-	handler := func(ctx context.Context, query string) (PreparedStatements, error) {
+	handler := func(ctx context.Context, query Query) (PreparedStatements, error) {
 		statement := NewStatement(func(ctx context.Context, writer DataWriter, parameters []Parameter) error {
 			queryStarted.Done()
 			queryCanFinish.Wait() // Block until test releases it
@@ -964,7 +964,7 @@ func TestServerShutdownTimeout(t *testing.T) {
 func TestServerShutdownConcurrent(t *testing.T) {
 	t.Parallel()
 
-	handler := func(ctx context.Context, query string) (PreparedStatements, error) {
+	handler := func(ctx context.Context, query Query) (PreparedStatements, error) {
 		statement := NewStatement(func(ctx context.Context, writer DataWriter, parameters []Parameter) error {
 			return writer.Complete("OK")
 		})
@@ -1001,7 +1001,7 @@ func TestServerShutdownConcurrent(t *testing.T) {
 func TestWithShutdownTimeoutOption(t *testing.T) {
 	t.Parallel()
 
-	handler := func(ctx context.Context, query string) (PreparedStatements, error) {
+	handler := func(ctx context.Context, query Query) (PreparedStatements, error) {
 		statement := NewStatement(func(ctx context.Context, writer DataWriter, parameters []Parameter) error {
 			return writer.Complete("OK")
 		})
@@ -1023,7 +1023,7 @@ func TestWithShutdownTimeoutOption(t *testing.T) {
 func TestServerShutdownInfiniteTimeout(t *testing.T) {
 	t.Parallel()
 
-	handler := func(ctx context.Context, query string) (PreparedStatements, error) {
+	handler := func(ctx context.Context, query Query) (PreparedStatements, error) {
 		statement := NewStatement(func(ctx context.Context, writer DataWriter, parameters []Parameter) error {
 			return writer.Complete("OK")
 		})
@@ -1055,7 +1055,7 @@ func TestServerShutdownInfiniteTimeoutWithActiveConnection(t *testing.T) {
 	queryStarted.Add(1)
 	queryCanFinish.Add(1)
 
-	handler := func(ctx context.Context, query string) (PreparedStatements, error) {
+	handler := func(ctx context.Context, query Query) (PreparedStatements, error) {
 		statement := NewStatement(func(ctx context.Context, writer DataWriter, parameters []Parameter) error {
 			queryStarted.Done()
 			queryCanFinish.Wait() // Block until test releases it
@@ -1156,7 +1156,7 @@ func TestClientDisconnectDuringWrite(t *testing.T) {
 	var brokenPipeWG sync.WaitGroup
 	brokenPipeWG.Add(1)
 
-	handler := func(ctx context.Context, query string) (PreparedStatements, error) {
+	handler := func(ctx context.Context, query Query) (PreparedStatements, error) {
 		// Handler that writes multiple rows to trigger broken pipe when client disconnects
 		statement := NewStatement(func(ctx context.Context, writer DataWriter, parameters []Parameter) error {
 			// Write enough data to fill buffers and ensure we hit the broken pipe
@@ -1253,7 +1253,7 @@ func TestCloseConnCallback(t *testing.T) {
 		var closeConnWG sync.WaitGroup
 		closeConnWG.Add(1)
 
-		handler := func(ctx context.Context, query string) (PreparedStatements, error) {
+		handler := func(ctx context.Context, query Query) (PreparedStatements, error) {
 			statement := NewStatement(func(ctx context.Context, writer DataWriter, parameters []Parameter) error {
 				return writer.Complete("OK")
 			})
@@ -1306,7 +1306,7 @@ func TestCloseConnCallback(t *testing.T) {
 		closeConnWG.Add(1)
 		terminateConnWG.Add(1)
 
-		handler := func(ctx context.Context, query string) (PreparedStatements, error) {
+		handler := func(ctx context.Context, query Query) (PreparedStatements, error) {
 			statement := NewStatement(func(ctx context.Context, writer DataWriter, parameters []Parameter) error {
 				return writer.Complete("OK")
 			})


### PR DESCRIPTION
This is a breaking change that changes ParseFn to take a Query struct instead of a query string. The reason is that the query string alone is not always enough to implement a handler that works correctly:

1. Clients might send parameter OIDs to the server and then encode the value as binary. psycopg does this for instance with integers and chooses the smallest integer type tat fits the integer. A handler cannot parse that binary correctly without knowing the type that the client sent to the server.
2. Using the Simple Query protocol it's valid to separate multiple queries from eachother with semicolons. With the extended protocol this is invalid, but you do have to parse the parameter placeholders. Supporting both semicolons and parameters at the same-time can be non-trivial to implement and the protocol does not require it, but without the handler knowing if the query was sent using the simple or extended protocol it's impossible to know which of the two the handler should be supporting.

Note: instead of adding parameters for each of these to the ParseFn there's now a new Query struct that encapsulates them all. This will allow any future additions to not require a breaking change.

Fixes #32
