### PR TITLE
Add protocol version negotiation

### DIFF
--- a/handshake.go
+++ b/handshake.go
@@ -8,7 +8,10 @@ import (
 	"log/slog"
 	"maps"
 	"net"
+	"strings"
 
+	"github.com/jeroenrinzema/psql-wire/codes"
+	psqlerr "github.com/jeroenrinzema/psql-wire/errors"
 	"github.com/jeroenrinzema/psql-wire/pkg/buffer"
 	"github.com/jeroenrinzema/psql-wire/pkg/types"
 )
@@ -115,10 +118,19 @@ func readyForQuery(writer *buffer.Writer, status types.ServerStatus) error {
 	return writer.End()
 }
 
+// protocolOptionPrefix identifies protocol-level options inside the startup
+// packet parameter list. Any parameter whose key starts with this prefix is
+// reserved for protocol extensions rather than being a regular server
+// (GUC) parameter.
+const protocolOptionPrefix = "_pq_."
+
 // readParameters reads the key/value connection parameters send by the client and
 // The read parameters will be set inside the given context. A new context containing
-// the consumed parameters will be returned.
-func (srv *Server) readClientParameters(ctx context.Context, reader *buffer.Reader) (_ context.Context, err error) {
+// the consumed parameters will be returned. Any parameter prefixed with
+// `_pq_.` is a protocol extension option; since this library does not
+// implement any such extension the keys are collected and returned so they can
+// be reported back to the client through a NegotiateProtocolVersion message.
+func (srv *Server) readClientParameters(ctx context.Context, reader *buffer.Reader) (_ context.Context, unrecognizedOptions []string, err error) {
 	meta := make(Parameters)
 
 	srv.logger.Debug("reading client parameters")
@@ -126,7 +138,7 @@ func (srv *Server) readClientParameters(ctx context.Context, reader *buffer.Read
 	for {
 		key, err := reader.GetString()
 		if err != nil {
-			return nil, err
+			return nil, nil, err
 		}
 
 		// an empty key indicates the end of the connection parameters
@@ -136,14 +148,85 @@ func (srv *Server) readClientParameters(ctx context.Context, reader *buffer.Read
 
 		value, err := reader.GetString()
 		if err != nil {
-			return nil, err
+			return nil, nil, err
+		}
+
+		if strings.HasPrefix(key, protocolOptionPrefix) {
+			srv.logger.Debug("unrecognized protocol option", slog.String("key", key))
+			unrecognizedOptions = append(unrecognizedOptions, key)
+			continue
 		}
 
 		srv.logger.Debug("client parameter", slog.String("key", key), slog.String("value", value))
 		meta[ParameterStatus(key)] = value
 	}
 
-	return setClientParameters(ctx, meta), nil
+	return setClientParameters(ctx, meta), unrecognizedOptions, nil
+}
+
+// checkProtocolVersion validates that the client requested a protocol major
+// version this library implements. Unlike the minor version, a differing major
+// version cannot be negotiated down to a supported one, so — matching the
+// PostgreSQL backend — the connection is rejected with a fatal error instead.
+// The error is written to the client before it is returned so the caller can
+// close the connection.
+func (srv *Server) checkProtocolVersion(writer *buffer.Writer, version types.Version) error {
+	if version.Major() == types.VersionLatest.Major() {
+		return nil
+	}
+
+	err := psqlerr.WithSeverity(
+		psqlerr.WithCode(
+			fmt.Errorf("unsupported frontend protocol %d.%d: server supports %d.0 to %d.%d",
+				version.Major(), version.Minor(),
+				types.VersionLatest.Major(),
+				types.VersionLatest.Major(), types.VersionLatest.Minor()),
+			codes.FeatureNotSupported),
+		psqlerr.LevelFatal)
+
+	if werr := WriteUnterminatedError(writer, err); werr != nil {
+		return werr
+	}
+
+	return err
+}
+
+// writeProtocolVersionNegotiation potentially informs the client that the
+// server speaks an older protocol version than the one requested, and lists
+// any protocol options that were not recognized. Following the PostgreSQL
+// backend, a NegotiateProtocolVersion message is only written when the client
+// requested a newer minor version than we implement or when it sent protocol
+// options we do not understand. When neither is the case this is a no-op and
+// the connection continues using the requested version.
+//
+// The negotiated version reported to the client is the older of the requested
+// version and the latest version this library implements, matching the
+// PostgreSQL behaviour of downgrading rather than rejecting the connection.
+func (srv *Server) writeProtocolVersionNegotiation(writer *buffer.Writer, requested types.Version, unrecognizedOptions []string) error {
+	if requested.Minor() <= types.VersionLatest.Minor() && len(unrecognizedOptions) == 0 {
+		return nil
+	}
+
+	negotiated := requested
+	if negotiated > types.VersionLatest {
+		negotiated = types.VersionLatest
+	}
+
+	srv.logger.Debug("negotiating protocol version",
+		slog.Uint64("requested", uint64(requested)),
+		slog.Uint64("negotiated", uint64(negotiated)),
+		slog.Int("unrecognized_options", len(unrecognizedOptions)),
+	)
+
+	writer.Start(types.ServerNegotiateVersion)
+	writer.AddInt32(int32(negotiated))
+	writer.AddInt32(int32(len(unrecognizedOptions)))
+	for _, option := range unrecognizedOptions {
+		writer.AddString(option)
+		writer.AddNullTerminate()
+	}
+
+	return writer.End()
 }
 
 // writeParameters writes the server parameters such as client encoding to the client.

--- a/handshake_test.go
+++ b/handshake_test.go
@@ -1,0 +1,123 @@
+package wire
+
+import (
+	"context"
+	"net"
+	"testing"
+
+	"github.com/jeroenrinzema/psql-wire/pkg/mock"
+	"github.com/jeroenrinzema/psql-wire/pkg/types"
+	"github.com/neilotoole/slogt"
+	"github.com/stretchr/testify/require"
+)
+
+// versionGrease is the "grease" protocol version (3.9999) that recent libpq
+// versions announce by default to verify that servers correctly implement
+// protocol version negotiation.
+var versionGrease = types.NewVersion(3, 9999)
+
+func TestProtocolVersionNegotiation(t *testing.T) {
+	t.Parallel()
+
+	handler := func(ctx context.Context, query string) (PreparedStatements, error) {
+		return Prepared(NewStatement(func(ctx context.Context, writer DataWriter, parameters []Parameter) error {
+			return writer.Complete("OK")
+		})), nil
+	}
+
+	server, err := NewServer(handler, Logger(slogt.New(t)))
+	require.NoError(t, err)
+	address := TListenAndServe(t, server)
+
+	tests := map[string]struct {
+		version         types.Version
+		params          []string
+		expectNegotiate bool
+		expectVersion   types.Version
+		expectOptions   []string
+	}{
+		"current version without options": {
+			version:         types.Version30,
+			params:          []string{"user", "mock"},
+			expectNegotiate: false,
+		},
+		"newer minor version": {
+			version:         types.Version32,
+			params:          []string{"user", "mock"},
+			expectNegotiate: true,
+			expectVersion:   types.Version30,
+			expectOptions:   []string{},
+		},
+		"grease version with protocol option": {
+			version:         versionGrease,
+			params:          []string{"user", "mock", "_pq_.test_protocol_negotiation", ""},
+			expectNegotiate: true,
+			expectVersion:   types.Version30,
+			expectOptions:   []string{"_pq_.test_protocol_negotiation"},
+		},
+		"current version with unrecognized protocol option": {
+			version:         types.Version30,
+			params:          []string{"user", "mock", "_pq_.test_protocol_negotiation", "on"},
+			expectNegotiate: true,
+			expectVersion:   types.Version30,
+			expectOptions:   []string{"_pq_.test_protocol_negotiation"},
+		},
+	}
+
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			conn, err := net.Dial("tcp", address.String())
+			require.NoError(t, err)
+
+			client := mock.NewClient(t, conn)
+			client.HandshakeProtocol(t, test.version, test.params...)
+
+			if test.expectNegotiate {
+				version, options := client.NegotiateProtocolVersion(t)
+				require.Equal(t, test.expectVersion, version)
+				require.Equal(t, test.expectOptions, options)
+			}
+
+			// Regardless of negotiation the connection must continue with the
+			// regular startup flow. A NegotiateProtocolVersion message (when
+			// present) is consumed above, so the next message is always the
+			// authentication response.
+			client.Authenticate(t)
+			client.ReadyForQuery(t)
+			client.Close(t)
+		})
+	}
+}
+
+func TestUnsupportedProtocolMajorVersion(t *testing.T) {
+	t.Parallel()
+
+	handler := func(ctx context.Context, query string) (PreparedStatements, error) {
+		return Prepared(NewStatement(func(ctx context.Context, writer DataWriter, parameters []Parameter) error {
+			return writer.Complete("OK")
+		})), nil
+	}
+
+	server, err := NewServer(handler, Logger(slogt.New(t)))
+	require.NoError(t, err)
+	address := TListenAndServe(t, server)
+
+	// A differing major version cannot be negotiated down, so the server must
+	// reject the connection with an error rather than sending a
+	// NegotiateProtocolVersion message.
+	versions := map[string]types.Version{
+		"older major version": types.NewVersion(2, 0),
+		"newer major version": types.NewVersion(4, 2),
+	}
+
+	for name, version := range versions {
+		t.Run(name, func(t *testing.T) {
+			conn, err := net.Dial("tcp", address.String())
+			require.NoError(t, err)
+
+			client := mock.NewClient(t, conn)
+			client.HandshakeProtocol(t, version, "user", "mock")
+			client.Error(t)
+		})
+	}
+}

--- a/pkg/mock/client.go
+++ b/pkg/mock/client.go
@@ -28,30 +28,73 @@ type Client struct {
 // connection preferences and the writing of (metadata) parameters identifying
 // the given client.
 func (client *Client) Handshake(t *testing.T) {
+	client.HandshakeProtocol(t, types.Version30, "client", "mock")
+}
+
+// HandshakeProtocol performs a handshake announcing the given protocol version
+// together with the provided startup parameters. The parameters are passed as
+// alternating key/value pairs. Protocol extension options (keys prefixed with
+// `_pq_.`) may be included among the parameters to exercise protocol version
+// negotiation.
+func (client *Client) HandshakeProtocol(t *testing.T, version types.Version, params ...string) {
 	t.Log("performing simple handshake")
 	defer t.Log("simple handshake completed")
 
-	version := make([]byte, 4)
-	binary.BigEndian.PutUint32(version, uint32(types.Version30))
+	if len(params)%2 != 0 {
+		t.Fatalf("expected an even number of key/value parameters, got %d", len(params))
+	}
+
+	versionBytes := make([]byte, 4)
+	binary.BigEndian.PutUint32(versionBytes, uint32(version))
 
 	// NOTE: the parameters consist out of keys and values. Each key and
 	// value is terminated using a nul byte and the end of all parameters is
 	// identified using a empty key value.
 	nul := byte(0)
-	key := append([]byte("client"), nul)
-	value := append([]byte("mock"), nul)
-	end := append([]byte(""), nul)
-	parameters := append(append(key, value...), end...)
+	var parameters []byte
+	for i := 0; i < len(params); i += 2 {
+		parameters = append(parameters, append([]byte(params[i]), nul)...)
+		parameters = append(parameters, append([]byte(params[i+1]), nul)...)
+	}
+	parameters = append(parameters, nul) // empty key terminates the parameter list
 
 	// NOTE: we have to define the total message length inside the
 	// header by prefixing a unsigned 32 big-endian int.
 	header := make([]byte, 4)
-	binary.BigEndian.PutUint32(header, uint32(len(version)+len(parameters)+len(header)))
+	binary.BigEndian.PutUint32(header, uint32(len(versionBytes)+len(parameters)+len(header)))
 
-	_, err := client.conn.Write(append(header, append(version, parameters...)...))
+	_, err := client.conn.Write(append(header, append(versionBytes, parameters...)...))
 	if err != nil {
 		t.Fatal(err)
 	}
+}
+
+// NegotiateProtocolVersion reads a NegotiateProtocolVersion message from the
+// server and returns the protocol version the server negotiated together with
+// the list of protocol options the server did not recognize.
+func (client *Client) NegotiateProtocolVersion(t *testing.T) (types.Version, []string) {
+	t.Helper()
+	t.Log("awaiting protocol version negotiation")
+	defer t.Log("protocol version negotiation received")
+
+	typed, _, err := client.ReadTypedMsg()
+	require.NoError(t, err)
+	require.Equal(t, types.ServerNegotiateVersion, typed, "unexpected message type %s, expected %s", typed, types.ServerNegotiateVersion)
+
+	version, err := client.GetUint32()
+	require.NoError(t, err)
+
+	num, err := client.GetUint32()
+	require.NoError(t, err)
+
+	options := make([]string, 0, num)
+	for i := uint32(0); i < num; i++ {
+		option, err := client.GetString()
+		require.NoError(t, err)
+		options = append(options, option)
+	}
+
+	return types.Version(version), options
 }
 
 // Authenticate performs a simple authentication using the PostgreSQL wire

--- a/pkg/types/types.go
+++ b/pkg/types/types.go
@@ -38,6 +38,7 @@ const (
 	ServerEmptyQuery           ServerMessage = 'I'
 	ServerErrorResponse        ServerMessage = 'E'
 	ServerNoticeResponse       ServerMessage = 'N'
+	ServerNegotiateVersion     ServerMessage = 'v'
 	ServerNoData               ServerMessage = 'n'
 	ServerParameterDescription ServerMessage = 't'
 	ServerParameterStatus      ServerMessage = 'S'
@@ -108,6 +109,8 @@ func (m ServerMessage) String() string {
 		return "ErrorResponse"
 	case ServerNoticeResponse:
 		return "NoticeResponse"
+	case ServerNegotiateVersion:
+		return "NegotiateProtocolVersion"
 	case ServerNoData:
 		return "NoData"
 	case ServerParameterDescription:

--- a/pkg/types/wire.go
+++ b/pkg/types/wire.go
@@ -1,20 +1,42 @@
 package types
 
-// Version represents a connection version presented inside the connection header
+// Version represents a connection version presented inside the connection
+// header. A version encodes a major and minor number as (major << 16) | minor.
 type Version uint32
 
-// The below constants can occur during the first message a client
-// sends to the server. There are two categories: protocol version and
-// request code. The protocol version is (major version number << 16)
-// + minor version number. Request codes are (1234 << 16) + 5678 + N,
-// where N started at 0 and is increased by 1 for every new request
-// code added, which happens rarely during major or minor Postgres
-// releases.
+// NewVersion constructs a Version from its major and minor numbers, matching
+// the on-the-wire encoding of (major << 16) | minor.
+func NewVersion(major, minor uint16) Version {
+	return Version(uint32(major)<<16 | uint32(minor))
+}
+
+// The below versions can occur during the first message a client sends to the
+// server. There are two categories: protocol versions and request codes.
+// Protocol versions carry the major and minor number directly. Request codes
+// reuse the same header with a reserved major number of 1234 followed by
+// 5678 + N, where N started at 0 and is increased by 1 for every new request
+// code added, which happens rarely during major or minor Postgres releases.
 //
 // See: https://www.postgresql.org/docs/current/protocol-message-formats.html
-const (
-	Version30         Version = 196608   // (3 << 16) + 0
-	VersionCancel     Version = 80877102 // (1234 << 16) + 5678
-	VersionSSLRequest Version = 80877103 // (1234 << 16) + 5679
-	VersionGSSENC     Version = 80877104 // (1234 << 16) + 5680
+var (
+	Version30         = NewVersion(3, 0)
+	Version32         = NewVersion(3, 2)
+	VersionCancel     = NewVersion(1234, 5678)
+	VersionSSLRequest = NewVersion(1234, 5679)
+	VersionGSSENC     = NewVersion(1234, 5680)
+
+	// VersionLatest is the highest protocol version implemented by this
+	// library. Clients requesting a newer minor version are negotiated back
+	// down to this version through a NegotiateProtocolVersion message.
+	VersionLatest = Version30
 )
+
+// Major returns the major protocol version number ((major << 16) | minor).
+func (v Version) Major() uint16 {
+	return uint16(v >> 16)
+}
+
+// Minor returns the minor protocol version number ((major << 16) | minor).
+func (v Version) Minor() uint16 {
+	return uint16(v & 0x0000ffff)
+}

--- a/wire.go
+++ b/wire.go
@@ -248,7 +248,24 @@ func (srv *Server) serve(ctx context.Context, conn net.Conn) error {
 
 	writer := buffer.NewWriter(srv.logger, conn)
 	writer.ErrorSanitizer = srv.ErrorSanitizer
-	ctx, err = srv.readClientParameters(ctx, reader)
+
+	// A differing major protocol version cannot be negotiated down, so reject
+	// it before consuming the rest of the startup packet. Only the minor
+	// version is negotiable (handled below).
+	err = srv.checkProtocolVersion(writer, version)
+	if err != nil {
+		return err
+	}
+
+	ctx, unrecognizedOptions, err := srv.readClientParameters(ctx, reader)
+	if err != nil {
+		return err
+	}
+
+	// A NegotiateProtocolVersion message must be sent (when applicable) after
+	// the startup packet has been consumed but before the authentication
+	// request, matching the message ordering used by the PostgreSQL backend.
+	err = srv.writeProtocolVersionNegotiation(writer, version, unrecognizedOptions)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
PostgreSQL 18 introduced protocol version 3.2, and the 19beta1 libpq defaults to announcing a "grease" protocol version of 3.9999 together with a `_pq_.test_protocol_negotiation` option to verify that servers correctly implement negotiation. Such clients abort the connection with `server incorrectly accepted "grease" protocol version 3.9999 without negotiation` unless the server responds appropriately.

When a client requests a newer minor version than the 3.0 implemented here, or sends `_pq_.`-prefixed protocol extension options we don't recognize, the server now replies with a `NegotiateProtocolVersion` message reporting the version it downgraded to (`3.0`) and echoing back the unrecognized options. Parameters prefixed with `_pq_.` are protocol-level options rather than regular server parameters, so they are peeled off the StartupMessage instead of being stored as GUCs. Because we always negotiate down to 3.0 the rest of the connection keeps using the 3.0 wire format, so nothing else needs to change.

The minor version is the only negotiable part: a differing major version cannot be downgraded, so it is rejected with a `FATAL` error before the rest of the StartupMessage is consumed.
