### PR TITLE
Remove stray line from MPL license from LICENSE file

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,5 +1,3 @@
-This Source Code Form is "Incompatible With Secondary Licenses", as
-defined by the Mozilla Public License, v. 2.0.
 
                                  Apache License
                            Version 2.0, January 2004


### PR DESCRIPTION
There was a leftover line from the MPL license appendix still at the top of the license file.

Related to #94
