### PR TITLE
fix: do not send RowDescription before a COPY's CopyInResponse

### DIFF
--- a/command.go
+++ b/command.go
@@ -330,9 +330,16 @@ func (srv *Session) handleSimpleQuery(ctx context.Context, reader *buffer.Reader
 
 	// NOTE: it is possible to send multiple statements in one simple query.
 	for index := range statements {
-		err = statements[index].columns.Define(ctx, writer, nil)
-		if err != nil {
-			return srv.WriteError(ctx, writer, err)
+		// PostgreSQL answers a COPY ... FROM STDIN query with a CopyInResponse
+		// and never sends a RowDescription for it. Strict drivers (lib/pq's
+		// prepareCopyIn) treat a leading RowDescription as fatal ("unknown
+		// response for copy query: 'T'") and abandon the connection, so the
+		// row description is suppressed for statements marked WithCopyIn.
+		if !statements[index].copyIn {
+			err = statements[index].columns.Define(ctx, writer, nil)
+			if err != nil {
+				return srv.WriteError(ctx, writer, err)
+			}
 		}
 
 		portal := &Portal{

--- a/copy_response_test.go
+++ b/copy_response_test.go
@@ -1,0 +1,141 @@
+package wire
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"net"
+	"testing"
+
+	"github.com/jackc/pgx/v5/pgproto3"
+	"github.com/jackc/pgx/v5/pgtype"
+	"github.com/neilotoole/slogt"
+)
+
+// TestCopyInSimpleQuerySuppressesRowDescription asserts the exact response
+// sequence for a simple-query COPY ... FROM STDIN on a statement marked
+// WithCopyIn: PostgreSQL answers such a query with a CopyInResponse and never
+// sends a RowDescription for it. The assertion runs at the raw protocol level
+// because tolerant clients (pgx) skip an unexpected RowDescription, while
+// strict ones (lib/pq's prepareCopyIn) abandon the connection on it ("unknown
+// response for copy query: 'T'").
+func TestCopyInSimpleQuerySuppressesRowDescription(t *testing.T) {
+	table := Columns{
+		{
+			Table: 0,
+			Name:  "id",
+			Oid:   pgtype.Int4OID,
+			Width: 4,
+		},
+	}
+
+	handler := func(ctx context.Context, query Query) (PreparedStatements, error) {
+		handle := func(ctx context.Context, writer DataWriter, parameters []Parameter) error {
+			reader, err := writer.CopyIn(TextFormat)
+			if err != nil {
+				return err
+			}
+
+			// Drain the (empty) COPY stream until the client's CopyDone.
+			for {
+				if err := reader.Read(ctx); err == io.EOF {
+					break
+				} else if err != nil {
+					return err
+				}
+			}
+
+			return writer.Complete("COPY 0")
+		}
+
+		return Prepared(NewStatement(handle, WithColumns(table), WithCopyIn())), nil
+	}
+
+	server, err := NewServer(handler, Logger(slogt.New(t)))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	address := TListenAndServe(t, server)
+
+	conn, err := net.Dial("tcp", fmt.Sprintf("%s:%d", address.IP, address.Port))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer conn.Close() //nolint:errcheck
+
+	frontend := pgproto3.NewFrontend(conn, conn)
+	frontend.Send(&pgproto3.StartupMessage{
+		ProtocolVersion: pgproto3.ProtocolVersionNumber,
+		Parameters:      map[string]string{"user": "copy-tester"},
+	})
+	if err := frontend.Flush(); err != nil {
+		t.Fatal(err)
+	}
+
+	// Consume the handshake up to the first ReadyForQuery.
+	for {
+		msg, err := frontend.Receive()
+		if err != nil {
+			t.Fatal(err)
+		}
+		if _, ok := msg.(*pgproto3.ReadyForQuery); ok {
+			break
+		}
+	}
+
+	frontend.Send(&pgproto3.Query{String: "COPY jedis FROM STDIN"})
+	if err := frontend.Flush(); err != nil {
+		t.Fatal(err)
+	}
+
+	// The first data-carrying response to the COPY query must be the
+	// CopyInResponse itself.
+	for {
+		msg, err := frontend.Receive()
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		switch typed := msg.(type) {
+		case *pgproto3.CopyInResponse:
+			if len(typed.ColumnFormatCodes) != len(table) {
+				t.Fatalf("CopyInResponse advertises %d columns, expected %d", len(typed.ColumnFormatCodes), len(table))
+			}
+		case *pgproto3.RowDescription:
+			t.Fatal("received a RowDescription in response to COPY ... FROM STDIN; PostgreSQL sends a CopyInResponse alone, and lib/pq aborts the connection on the stray message")
+		case *pgproto3.ErrorResponse:
+			t.Fatalf("unexpected error response: %s", typed.Message)
+		default:
+			t.Fatalf("unexpected message %T before the CopyInResponse", msg)
+		}
+		break
+	}
+
+	// Complete the (empty) copy operation and drain to ReadyForQuery so the
+	// full exchange round-trips.
+	frontend.Send(&pgproto3.CopyDone{})
+	if err := frontend.Flush(); err != nil {
+		t.Fatal(err)
+	}
+
+	sawComplete := false
+	for {
+		msg, err := frontend.Receive()
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		switch typed := msg.(type) {
+		case *pgproto3.CommandComplete:
+			sawComplete = true
+		case *pgproto3.ReadyForQuery:
+			if !sawComplete {
+				t.Fatal("ReadyForQuery arrived without a CommandComplete for the COPY")
+			}
+			return
+		case *pgproto3.ErrorResponse:
+			t.Fatalf("unexpected error response: %s", typed.Message)
+		}
+	}
+}

--- a/options.go
+++ b/options.go
@@ -93,12 +93,27 @@ func WithParameters(parameters []uint32) PreparedOptionFn {
 	}
 }
 
+// WithCopyIn marks the prepared statement as a COPY ... FROM STDIN statement.
+// PostgreSQL answers such a query with a CopyInResponse and never sends a
+// RowDescription for it, so the simple query protocol suppresses the
+// RowDescription it would otherwise write for the statement's columns. The
+// columns themselves are still required - they define the CopyInResponse's
+// column count and format codes. Strict drivers (lib/pq's prepareCopyIn)
+// abandon the connection on a RowDescription where a CopyInResponse is
+// expected ("unknown response for copy query: 'T'").
+func WithCopyIn() PreparedOptionFn {
+	return func(stmt *PreparedStatement) {
+		stmt.copyIn = true
+	}
+}
+
 type PreparedStatements []*PreparedStatement
 
 type PreparedStatement struct {
 	fn         PreparedStatementFn
 	parameters []uint32
 	columns    Columns
+	copyIn     bool
 }
 
 // SessionHandler represents a wrapper function defining the state of a single


### PR DESCRIPTION
## Problem

PostgreSQL answers a `COPY ... FROM STDIN` query with a `CopyInResponse` and never sends a `RowDescription` for it ([protocol docs — COPY operations](https://www.postgresql.org/docs/current/protocol-flow.html#PROTOCOL-COPY)). `handleSimpleQuery` writes the statement's column description before executing every statement, so a COPY statement currently produces `RowDescription` ('T') followed by `CopyInResponse` ('G').

Tolerant drivers (pgx) skip the unexpected message — but lib/pq's `prepareCopyIn` accepts only 'G'/'H'/'E'/'Z' and fails hard on the stray 'T':

```
pq: unknown response for copy query: 'T'
```

marking the connection `driver.ErrBadConn` and disconnecting. This makes COPY unusable from lib/pq and from tools built on it (we hit this in production with RudderStack's Postgres warehouse loads against a psql-wire-based server; the server side then sees the client's Terminate byte arrive mid-COPY).

## Fix

The columns can't simply be omitted from the prepared statement — `Columns.CopyIn` uses them to build the `CopyInResponse`'s column count and format codes, and errors when they're empty. So this adds an explicit marker, following the existing prepared-statement option pattern:

- `WithCopyIn()` `PreparedOptionFn` marks a statement as `COPY ... FROM STDIN`.
- `handleSimpleQuery` skips `columns.Define` for marked statements.

Behavior is unchanged for statements without the marker, so existing servers are unaffected until they opt in.

## Test

The regression test asserts the response sequence at the raw protocol level with pgproto3 (already available via the pgx v5 dependency), since pgx-based tests can't observe the stray message: it fails on `main` with `received a RowDescription in response to COPY ... FROM STDIN` and passes with the fix. Full suite passes.

## Possible follow-up (not included)

An extended-protocol `Describe` of a COPY statement still answers with `RowDescription` where PostgreSQL sends `NoData`. No mainstream driver takes that path for COPY (lib/pq, pgx, and PgJDBC's CopyManager all send COPY as a simple query), and handling it means carrying the marker through the statement cache and both pipeline modes — happy to do that as a separate PR if you'd like.

---

We currently run this patch vendored; happy to adjust naming/approach to whatever fits the project (e.g. if you'd rather infer COPY server-side than add an option).